### PR TITLE
test: backfill coverage for shared abstractions + PackageTestCase hardening

### DIFF
--- a/src/Providers/PackageServiceProvider.php
+++ b/src/Providers/PackageServiceProvider.php
@@ -12,6 +12,14 @@ abstract class PackageServiceProvider extends BasePackageServiceProvider
     /** Module short-name, e.g. 'blog'. */
     abstract protected function module(): string;
 
+    /**
+     * Build the fully-qualified, module-namespaced config key (e.g. "blog.title").
+     *
+     * This produces the dotted key string; reading the value at that key is the
+     * job of the InteractsWithModuleConfig::moduleConfig() trait method, which
+     * uses the same "{module}.{key}" convention. The two share the naming scheme
+     * but sit at different layers: this returns the key, the trait reads it.
+     */
     final protected function configKey(string $key): string
     {
         return "{$this->module()}.{$key}";

--- a/src/Testing/PackageTestCase.php
+++ b/src/Testing/PackageTestCase.php
@@ -48,6 +48,17 @@ abstract class PackageTestCase extends BaseTestCase
 
     protected function defineDatabaseMigrations(): void
     {
+        $this->createUsersTable();
+    }
+
+    /**
+     * Create the shared `users` table used across module tests.
+     *
+     * Extracted so downstream overrides of {@see defineDatabaseMigrations()}
+     * can call it explicitly and avoid silently dropping the shared table.
+     */
+    protected function createUsersTable(): void
+    {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
             $table->string('name')->nullable();

--- a/tests/Feature/CoreServiceProviderTest.php
+++ b/tests/Feature/CoreServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Schema;
 use Kurt\Modules\Core\Contracts\UserResolver;
 use Kurt\Modules\Core\Support\ConfigUserResolver;
 use Kurt\Modules\Core\Tests\Stubs\StubUser;
@@ -12,6 +13,10 @@ it('binds UserResolver to ConfigUserResolver', function () {
 
 it('publishes config under kurtmodules key', function () {
     expect(config('kurtmodules.date_format'))->toBe('Y-m-d H:i:s');
+});
+
+it('creates the shared users table via defineDatabaseMigrations', function () {
+    expect(Schema::hasTable('users'))->toBeTrue();
 });
 
 it('resolves the user model when configured', function () {

--- a/tests/Feature/PackageServiceProviderTest.php
+++ b/tests/Feature/PackageServiceProviderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Core\Support\FilamentVersion;
+use Kurt\Modules\Core\Tests\Stubs\StubFilamentProvider;
+
+afterEach(function () {
+    FilamentVersion::override(null);
+});
+
+function makeStubProvider(): StubFilamentProvider
+{
+    return new StubFilamentProvider(app());
+}
+
+it('dispatches to registerFilamentV3 when filament major is 3', function () {
+    FilamentVersion::override('3.2.1');
+
+    $provider = makeStubProvider();
+    $provider->dispatchFilament();
+
+    expect($provider->fired)->toBe([3]);
+});
+
+it('dispatches to registerFilamentV4 when filament major is 4', function () {
+    FilamentVersion::override('4.0.0');
+
+    $provider = makeStubProvider();
+    $provider->dispatchFilament();
+
+    expect($provider->fired)->toBe([4]);
+});
+
+it('dispatches to registerFilamentV5 when filament major is 5', function () {
+    FilamentVersion::override('5.1.3');
+
+    $provider = makeStubProvider();
+    $provider->dispatchFilament();
+
+    expect($provider->fired)->toBe([5]);
+});
+
+it('is a no-op when filament is not installed', function () {
+    FilamentVersion::override(false);
+
+    $provider = makeStubProvider();
+    $provider->dispatchFilament();
+
+    expect($provider->fired)->toBe([]);
+});
+
+it('is a no-op for an unsupported filament major', function () {
+    FilamentVersion::override('2.9.9');
+
+    $provider = makeStubProvider();
+    $provider->dispatchFilament();
+
+    expect($provider->fired)->toBe([]);
+});

--- a/tests/Feature/UserResolverTest.php
+++ b/tests/Feature/UserResolverTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Kurt\Modules\Core\Contracts\UserResolver;
+use Kurt\Modules\Core\Support\ConfigUserResolver;
+use Kurt\Modules\Core\Tests\Stubs\StubPost;
+use Kurt\Modules\Core\Tests\Stubs\StubUser;
+
+beforeEach(function () {
+    config()->set('kurtmodules.user_model', StubUser::class);
+});
+
+it('resolves the bound UserResolver via the trait', function () {
+    expect((new StubPost)->resolver())->toBeInstanceOf(ConfigUserResolver::class);
+});
+
+it('builds a BelongsTo targeting the configured user model with the right keys', function () {
+    $relation = (new StubPost)->user();
+
+    expect($relation)->toBeInstanceOf(BelongsTo::class)
+        ->and($relation->getRelated())->toBeInstanceOf(StubUser::class)
+        ->and($relation->getForeignKeyName())->toBe('user_id')
+        ->and($relation->getOwnerKeyName())->toBe('id');
+});
+
+it('honours a custom foreign key', function () {
+    $relation = (new StubPost)->user('author_id');
+
+    expect($relation->getForeignKeyName())->toBe('author_id')
+        ->and($relation->getOwnerKeyName())->toBe('id');
+});
+
+it('newQuery returns an Eloquent Builder for the user model', function () {
+    $resolver = app(UserResolver::class);
+
+    $query = $resolver->newQuery();
+
+    expect($query)->toBeInstanceOf(Builder::class)
+        ->and($query->getModel())->toBeInstanceOf(StubUser::class);
+});

--- a/tests/Stubs/StubFilamentProvider.php
+++ b/tests/Stubs/StubFilamentProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Tests\Stubs;
+
+use Kurt\Modules\Core\Providers\PackageServiceProvider;
+use Spatie\LaravelPackageTools\Package;
+
+final class StubFilamentProvider extends PackageServiceProvider
+{
+    /** @var list<int> Major versions whose hook fired, in order. */
+    public array $fired = [];
+
+    public function configurePackage(Package $package): void
+    {
+        $package->name('stub');
+    }
+
+    protected function module(): string
+    {
+        return 'stub';
+    }
+
+    /** Expose the protected dispatch entry point for testing. */
+    public function dispatchFilament(): void
+    {
+        $this->registerFilament();
+    }
+
+    protected function registerFilamentV3(): void
+    {
+        $this->fired[] = 3;
+    }
+
+    protected function registerFilamentV4(): void
+    {
+        $this->fired[] = 4;
+    }
+
+    protected function registerFilamentV5(): void
+    {
+        $this->fired[] = 5;
+    }
+}

--- a/tests/Stubs/StubPost.php
+++ b/tests/Stubs/StubPost.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Tests\Stubs;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Kurt\Modules\Core\Concerns\ResolvesUser;
+use Kurt\Modules\Core\Contracts\UserResolver;
+
+final class StubPost extends Model
+{
+    use ResolvesUser;
+
+    protected $table = 'posts';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    /** Expose the trait relation for testing. */
+    public function user(string $foreignKey = 'user_id'): BelongsTo
+    {
+        return $this->userBelongsTo($foreignKey);
+    }
+
+    /** Expose the resolved resolver for testing. */
+    public function resolver(): UserResolver
+    {
+        return $this->userResolver();
+    }
+}

--- a/tests/Unit/Support/ConfigUserResolverTest.php
+++ b/tests/Unit/Support/ConfigUserResolverTest.php
@@ -48,3 +48,14 @@ it('throws when neither config key is set', function () {
     expect(fn () => (new ConfigUserResolver($config))->modelClass())
         ->toThrow(RuntimeException::class);
 });
+
+it('throws when the configured user model does not extend Model', function () {
+    $config = makeConfig([
+        'kurtmodules' => ['user_model' => stdClass::class],
+    ]);
+
+    $resolver = new ConfigUserResolver($config);
+
+    expect(fn () => $resolver->primaryKey())
+        ->toThrow(RuntimeException::class, 'must extend');
+});


### PR DESCRIPTION
## Summary

Test-coverage backfill for the untested shared abstractions in the KurtModules bootstrap kit, plus one small hardening change and a documentation note. Every downstream module depends on these, so the tests protect the whole ecosystem.

## Changes

**1. Filament version dispatch** (`PackageServiceProvider::registerFilament()`)
- New `tests/Stubs/StubFilamentProvider.php` subclass records which `registerFilamentVN()` hook fires.
- `tests/Feature/PackageServiceProviderTest.php` uses `FilamentVersion::override(...)` to assert v3 -> V3, v4 -> V4, v5 -> V5, no-op when not installed, and no-op for an unsupported major (e.g. 2).

**2. `ResolvesUser` trait**
- New `tests/Stubs/StubPost.php` model uses the trait.
- `tests/Feature/UserResolverTest.php` asserts `userResolver()` resolves the bound `ConfigUserResolver`, and `userBelongsTo()` returns a `BelongsTo` targeting the configured model with the correct foreign/owner keys (incl. a custom foreign key).

**3. `ConfigUserResolver`**
- Feature test asserts `newQuery()` returns an Eloquent `Builder` for the configured model.
- Unit test asserts the "must extend Model" guard throws `RuntimeException` for a non-Model class.

**4. `PackageTestCase::defineDatabaseMigrations()` chainable**
- Extracted the `users` table creation into a `protected createUsersTable()` helper so a downstream override can call it without silently dropping the shared table. Default behavior unchanged (the helper is called from `defineDatabaseMigrations()`).
- Added a test asserting the `users` table exists.

**5. (Minor) `configKey()` / `moduleConfig()` layering** — documented the shared `{module}.{key}` naming convention and how the two sit at different layers.

## Gates
- Pest: 27 passed / 52 assertions (was 16 passed).
- PHPStan level 8: no errors.
- Pint: clean (verified on LF-normalized files; repo uses `core.autocrlf`).
- Coverage gate (50%) untouched; PHP `^8.3` constraint untouched.

No changes to the `UserResolver` public contract.
