### PR TITLE
fix: audit round 2 hardening

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,13 @@
+* text=auto eol=lf
+
 /.github                export-ignore
 /tests                  export-ignore
 /.gitattributes         export-ignore
 /.gitignore             export-ignore
 /phpstan.neon           export-ignore
+/phpunit.xml.dist       export-ignore
 /pint.json              export-ignore
 /rector.php             export-ignore
 /.editorconfig          export-ignore
+/CHANGELOG.md           export-ignore
+/UPGRADE-2.0.md         export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,14 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ['8.4']
+                php: ['8.3', '8.4']
                 laravel: ['12.*']
                 include:
                     - laravel: 12.*
                       testbench: 10.*
-                # Laravel 13 will be added once pestphp/pest-plugin-laravel
-                # publishes a release supporting laravel/framework ^13.0.
+                # Laravel 13 is not yet supported: orchestra/testbench caps at
+                # ^10 (Laravel 12) and pestphp/pest-plugin-laravel has no ^13
+                # release, so it stays out of both composer.json and this matrix.
 
         name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Shared bootstrap kit for [KurtModules](https://github.com/ozankurt) Laravel pack
 
 ## Requirements
 
-- PHP 8.4+
-- Laravel 12.x or 13.x
+- PHP 8.3+
+- Laravel 12.x
 - (Optional) Filament 3, 4, or 5
 
 ## Installation
@@ -35,7 +35,6 @@ php artisan vendor:publish --tag="kurtmodules-config"
 ```php
 return [
     'user_model' => env('KURTMODULES_USER_MODEL'),
-    'date_format' => 'Y-m-d H:i:s',
 ];
 ```
 

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -34,4 +34,4 @@ Update `composer.json`, run `composer update`.
 
 ## New requirement
 
-PHP 8.4 is now the minimum. Laravel 12 or 13 only.
+PHP 8.3 is now the minimum. Laravel 12 only.

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
   "authors": [{ "name": "Ozan Kurt", "email": "ozankurt2@gmail.com" }],
   "require": {
     "php": "^8.3",
-    "illuminate/contracts": "^12.0 || ^13.0",
-    "illuminate/database": "^12.0 || ^13.0",
-    "illuminate/support": "^12.0 || ^13.0",
+    "illuminate/contracts": "^12.0",
+    "illuminate/database": "^12.0",
+    "illuminate/support": "^12.0",
     "spatie/laravel-package-tools": "^1.92"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "56554d3149a650ec426888c7072475b6",
+    "content-hash": "54054aafbdd2611f98d39099fb353cae",
     "packages": [
         {
             "name": "brick/math",
@@ -12142,7 +12142,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.4"
+        "php": "^8.3"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/config/kurtmodules.php
+++ b/config/kurtmodules.php
@@ -13,6 +13,4 @@ return [
     */
 
     'user_model' => env('KURTMODULES_USER_MODEL'),
-
-    'date_format' => 'Y-m-d H:i:s',
 ];

--- a/src/Providers/PackageServiceProvider.php
+++ b/src/Providers/PackageServiceProvider.php
@@ -9,8 +9,26 @@ use Spatie\LaravelPackageTools\PackageServiceProvider as BasePackageServiceProvi
 
 abstract class PackageServiceProvider extends BasePackageServiceProvider
 {
+    /** Guards against wiring Filament resources more than once per instance. */
+    private bool $filamentRegistered = false;
+
     /** Module short-name, e.g. 'blog'. */
     abstract protected function module(): string;
+
+    /**
+     * Wire Filament resources as part of the standard package boot lifecycle.
+     *
+     * Downstream providers only need to override registerFilamentV{3,4,5} — the
+     * base handles dispatch. Providers that override packageBooted() themselves
+     * should call parent::packageBooted(); calling registerFilament() again is
+     * harmless because it is idempotent per instance.
+     */
+    public function packageBooted(): void
+    {
+        parent::packageBooted();
+
+        $this->registerFilament();
+    }
 
     /**
      * Build the fully-qualified, module-namespaced config key (e.g. "blog.title").
@@ -31,6 +49,12 @@ abstract class PackageServiceProvider extends BasePackageServiceProvider
      */
     final protected function registerFilament(): void
     {
+        if ($this->filamentRegistered) {
+            return;
+        }
+
+        $this->filamentRegistered = true;
+
         $major = FilamentVersion::major();
 
         match (true) {

--- a/src/Support/ConfigUserResolver.php
+++ b/src/Support/ConfigUserResolver.php
@@ -48,6 +48,13 @@ final class ConfigUserResolver implements UserResolver
     {
         $class = $this->modelClass();
 
+        if (! class_exists($class)) {
+            throw new RuntimeException(sprintf(
+                'Configured user model [%s] class not found.',
+                $class,
+            ));
+        }
+
         if (! is_subclass_of($class, Model::class)) {
             throw new RuntimeException(sprintf(
                 'Configured user model [%s] must extend %s.',

--- a/tests/Feature/CoreServiceProviderTest.php
+++ b/tests/Feature/CoreServiceProviderTest.php
@@ -12,7 +12,7 @@ it('binds UserResolver to ConfigUserResolver', function () {
 });
 
 it('publishes config under kurtmodules key', function () {
-    expect(config('kurtmodules.date_format'))->toBe('Y-m-d H:i:s');
+    expect(config()->has('kurtmodules.user_model'))->toBeTrue();
 });
 
 it('creates the shared users table via defineDatabaseMigrations', function () {

--- a/tests/Feature/PackageServiceProviderTest.php
+++ b/tests/Feature/PackageServiceProviderTest.php
@@ -58,3 +58,28 @@ it('is a no-op for an unsupported filament major', function () {
 
     expect($provider->fired)->toBe([]);
 });
+
+it('fires the overridden filament hook through the package boot lifecycle', function () {
+    FilamentVersion::override('5.1.3');
+
+    // Register the provider the way Laravel does: this drives the full
+    // register + boot lifecycle, so packageBooted() (not the test-only
+    // dispatch wrapper) is what invokes the overridden registerFilamentV5.
+    $provider = app()->register(new StubFilamentProvider(app()));
+
+    expect($provider->fired)->toBe([5]);
+});
+
+it('does not double-register when a provider re-invokes registerFilament', function () {
+    FilamentVersion::override('4.0.0');
+
+    $provider = makeStubProvider();
+
+    // Simulate a downstream provider whose packageBooted() calls
+    // parent::packageBooted() (which wires Filament) and then also wires it
+    // itself: the per-instance guard keeps it to a single registration.
+    $provider->packageBooted();
+    $provider->dispatchFilament();
+
+    expect($provider->fired)->toBe([4]);
+});

--- a/tests/Unit/Support/ConfigUserResolverTest.php
+++ b/tests/Unit/Support/ConfigUserResolverTest.php
@@ -49,6 +49,17 @@ it('throws when neither config key is set', function () {
         ->toThrow(RuntimeException::class);
 });
 
+it('throws a class-not-found error when the configured user model does not exist', function () {
+    $config = makeConfig([
+        'kurtmodules' => ['user_model' => 'App\\Models\\DoesNotExist'],
+    ]);
+
+    $resolver = new ConfigUserResolver($config);
+
+    expect(fn () => $resolver->primaryKey())
+        ->toThrow(RuntimeException::class, 'class not found');
+});
+
 it('throws when the configured user model does not extend Model', function () {
     $config = makeConfig([
         'kurtmodules' => ['user_model' => stdClass::class],


### PR DESCRIPTION
Second-round audit fixes for the bootstrap kit.

## Fixes

1. **Version/doc/CI drift** (High) — README and UPGRADE-2.0 claimed "PHP 8.4+" while composer requires `^8.3`; docs now say **PHP 8.3+** and **Laravel 12.x**. Dropped the untestable `illuminate/* ^13.0` from composer (testbench caps at `^10`, pest-plugin-laravel has no `^13` release) and added an **8.3 leg** to the CI matrix. The commented L13 note in the workflow now explains why it stays out.
2. **`registerFilament()` never auto-invoked** (Med) — the base `PackageServiceProvider::packageBooted()` now calls `registerFilament()`, so a downstream provider only needs to override `registerFilamentV{3,4,5}`. A per-instance guard makes `registerFilament()` idempotent, so providers that already call it (directly or via `parent::packageBooted()`) won't double-register.
3. **`ConfigUserResolver` misleading error** (Low) — a nonexistent `user_model` now throws "class not found" via a `class_exists()` check before `is_subclass_of`, instead of the misleading "must extend Model".
4. **`.gitattributes`** (Low) — added `* text=auto eol=lf` normalization and export-ignore for `phpunit.xml.dist`, `CHANGELOG.md`, `UPGRADE-2.0.md`.
5. **Dead `date_format` config knob** (Low) — removed; it was never read anywhere.

## Deferred

- **`AbortsInProduction` trait** (fix 6, optional) — deferred. The `*:demo` guard lives in the downstream module repos, which aren't visible from Core; adding a shared trait blind risks a signature mismatch with what those modules actually call. Best done alongside a module that consumes it so the API is verified. Noted as a future item.

## Verification

- Pest: 30 passed (56 assertions) on PHP 8.4 — includes new regression tests for the boot-lifecycle wiring, the idempotency guard, and both resolver error messages.
- PHPStan level 8: no errors.
- Pint: clean on changed files.