### PR TITLE
feat: AbortsInProduction and HasEnumLabels traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ composer require ozankurt/laravel-modules-core
 - `Kurt\Modules\Core\Contracts\UserResolver` (+ `ConfigUserResolver`) — resolves the consumer's user model via `kurtmodules.user_model` config or `auth.providers.users.model` fallback.
 - `Kurt\Modules\Core\Concerns\ResolvesUser` — trait that gives module models a `userBelongsTo()` helper.
 - `Kurt\Modules\Core\Concerns\InteractsWithModuleConfig` — sugar for `config("{module}.key")` access.
+- `Kurt\Modules\Core\Concerns\AbortsInProduction` — trait for Artisan commands; `abortIfProduction()` blocks demo/destructive commands in production unless `--force` is passed. Lets `*:demo` commands drop their hand-rolled guards.
+- `Kurt\Modules\Core\Concerns\HasEnumLabels` — trait giving string-backed enums a Title-Case `getLabel()` and a null `getColor()` default, so downstream enums can satisfy Filament's `HasLabel`/`HasColor` without Core requiring Filament.
 - `Kurt\Modules\Core\Support\FilamentVersion` — `::major()`, `::isAtLeast()`, `::isExactly()`.
 - `Kurt\Modules\Core\Enums\{Approval,MediaKind,Visibility}` — generic cross-module enums.
 - `Kurt\Modules\Core\Testing\PackageTestCase` — Testbench-backed base test case with an in-memory `users` table.
@@ -36,6 +38,59 @@ php artisan vendor:publish --tag="kurtmodules-config"
 return [
     'user_model' => env('KURTMODULES_USER_MODEL'),
 ];
+```
+
+## Command & enum helpers
+
+Guard demo/destructive Artisan commands so they cannot run in production without `--force`:
+
+```php
+use Illuminate\Console\Command;
+use Kurt\Modules\Core\Concerns\AbortsInProduction;
+
+class SeedDemoCommand extends Command
+{
+    use AbortsInProduction;
+
+    protected $signature = 'blog:demo {--force}';
+
+    public function handle(): int
+    {
+        if ($this->abortIfProduction()) {
+            return self::FAILURE;
+        }
+
+        // ... seed demo data ...
+
+        return self::SUCCESS;
+    }
+}
+```
+
+Give a string-backed enum Filament-ready labels/colors without Core depending on Filament (the enum declares the contracts, the trait supplies the bodies):
+
+```php
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+use Kurt\Modules\Core\Concerns\HasEnumLabels;
+
+enum Status: string implements HasColor, HasLabel
+{
+    use HasEnumLabels;
+
+    case Draft = 'draft';
+    case InReview = 'in_review'; // getLabel() => "In Review"
+    case Published = 'published';
+
+    // Optional: override getColor() per case; getLabel() keeps the default.
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::Published => 'success',
+            default => null,
+        };
+    }
+}
 ```
 
 ## License

--- a/src/Concerns/AbortsInProduction.php
+++ b/src/Concerns/AbortsInProduction.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Concerns;
+
+use Illuminate\Console\Command;
+
+/**
+ * Guards destructive or demo Artisan commands against accidental execution in
+ * production. Consuming commands return FAILURE when the guard trips:
+ *
+ *     public function handle(): int
+ *     {
+ *         if ($this->abortIfProduction()) {
+ *             return self::FAILURE;
+ *         }
+ *
+ *         // ... seed demo data ...
+ *
+ *         return self::SUCCESS;
+ *     }
+ *
+ * @mixin Command
+ */
+trait AbortsInProduction
+{
+    /**
+     * Print an error and signal the caller to abort when running in production
+     * without an explicit `--force` override.
+     *
+     * @return bool True when the command should abort (production + not forced).
+     */
+    protected function abortIfProduction(): bool
+    {
+        if (! $this->getLaravel()->isProduction()) {
+            return false;
+        }
+
+        if ($this->isForced()) {
+            return false;
+        }
+
+        $this->error('This command is disabled in production. Re-run with --force to override.');
+
+        return true;
+    }
+
+    /**
+     * Whether a truthy `--force` flag was supplied. Safe to call on commands
+     * that do not declare the option (returns false rather than throwing).
+     */
+    protected function isForced(): bool
+    {
+        return $this->hasOption('force') && (bool) $this->option('force');
+    }
+}

--- a/src/Concerns/HasEnumLabels.php
+++ b/src/Concerns/HasEnumLabels.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Concerns;
+
+use Illuminate\Support\Str;
+
+/**
+ * Default `getLabel()` / `getColor()` behaviour for string-backed enums so that
+ * downstream modules can satisfy Filament's `HasLabel` / `HasColor` contracts
+ * without Core taking a hard dependency on Filament.
+ *
+ * The consuming enum declares the Filament contracts; this trait only supplies
+ * the method bodies:
+ *
+ *     use Filament\Support\Contracts\HasColor;
+ *     use Filament\Support\Contracts\HasLabel;
+ *     use Kurt\Modules\Core\Concerns\HasEnumLabels;
+ *
+ *     enum Status: string implements HasColor, HasLabel
+ *     {
+ *         use HasEnumLabels;
+ *
+ *         case InReview = 'in_review';
+ *         case Published = 'published';
+ *     }
+ *
+ * `Status::InReview->getLabel()` yields "In Review". Override `getColor()` (or
+ * `getLabel()`) per case in the enum when a static default is not enough.
+ *
+ * @phpstan-require-implements \UnitEnum
+ */
+trait HasEnumLabels
+{
+    /**
+     * Human-readable label derived from the case name (e.g. `InReview` -> "In Review").
+     */
+    public function getLabel(): ?string
+    {
+        return Str::headline($this->name);
+    }
+
+    /**
+     * Default color. Returns null so Filament falls back to its own default;
+     * override per case in the consuming enum to assign colors.
+     *
+     * @return string|array<string>|null
+     */
+    public function getColor(): string|array|null
+    {
+        return null;
+    }
+}

--- a/tests/Feature/AbortsInProductionTest.php
+++ b/tests/Feature/AbortsInProductionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Core\Tests\Stubs\StubDemoCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @return array{code:int, output:string}
+ */
+function runStubDemo(array $parameters = []): array
+{
+    $app = app();
+
+    $command = new StubDemoCommand;
+    $command->setLaravel($app);
+
+    $output = new BufferedOutput;
+    $code = $command->run(new ArrayInput($parameters), $output);
+
+    return ['code' => $code, 'output' => $output->fetch()];
+}
+
+it('runs normally in a non-production environment', function () {
+    $this->app['env'] = 'local';
+
+    $result = runStubDemo();
+
+    expect($this->app->isProduction())->toBeFalse();
+    expect($result['code'])->toBe(0);
+    expect($result['output'])->toContain('demo ran');
+});
+
+it('aborts in production without --force', function () {
+    $this->app['env'] = 'production';
+
+    $result = runStubDemo();
+
+    expect($this->app->isProduction())->toBeTrue();
+    expect($result['code'])->toBe(1);
+    expect($result['output'])->toContain('disabled in production');
+});
+
+it('runs in production when --force is passed', function () {
+    $this->app['env'] = 'production';
+
+    $result = runStubDemo(['--force' => true]);
+
+    expect($result['code'])->toBe(0);
+    expect($result['output'])->toContain('demo ran');
+});

--- a/tests/Stubs/StubColoredStatus.php
+++ b/tests/Stubs/StubColoredStatus.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Tests\Stubs;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+use Kurt\Modules\Core\Concerns\HasEnumLabels;
+
+/**
+ * Overrides `getColor()` per case to show a downstream enum can keep the trait's
+ * default label while supplying its own colors.
+ */
+enum StubColoredStatus: string implements HasColor, HasLabel
+{
+    use HasEnumLabels;
+
+    case Pending = 'pending';
+    case Approved = 'approved';
+
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::Approved => 'success',
+            self::Pending => 'warning',
+        };
+    }
+}

--- a/tests/Stubs/StubDemoCommand.php
+++ b/tests/Stubs/StubDemoCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Tests\Stubs;
+
+use Illuminate\Console\Command;
+use Kurt\Modules\Core\Concerns\AbortsInProduction;
+
+final class StubDemoCommand extends Command
+{
+    use AbortsInProduction;
+
+    protected $signature = 'stub:demo {--force : Bypass the production guard}';
+
+    protected $description = 'Stub command exercising the production guard.';
+
+    public function handle(): int
+    {
+        if ($this->abortIfProduction()) {
+            return self::FAILURE;
+        }
+
+        $this->info('demo ran');
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Stubs/StubStatus.php
+++ b/tests/Stubs/StubStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Tests\Stubs;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+use Kurt\Modules\Core\Concerns\HasEnumLabels;
+
+/**
+ * Uses Core's trait for the method bodies while declaring Filament's contracts
+ * in the (downstream) enum, mirroring how modules consume {@see HasEnumLabels}.
+ */
+enum StubStatus: string implements HasColor, HasLabel
+{
+    use HasEnumLabels;
+
+    case Draft = 'draft';
+    case InReview = 'in_review';
+    case Published = 'published';
+}

--- a/tests/Unit/Concerns/HasEnumLabelsTest.php
+++ b/tests/Unit/Concerns/HasEnumLabelsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+use Kurt\Modules\Core\Tests\Stubs\StubColoredStatus;
+use Kurt\Modules\Core\Tests\Stubs\StubStatus;
+
+it('derives a title-cased label from the case name', function () {
+    expect(StubStatus::Draft->getLabel())->toBe('Draft');
+    expect(StubStatus::InReview->getLabel())->toBe('In Review');
+    expect(StubStatus::Published->getLabel())->toBe('Published');
+});
+
+it('returns a null color by default', function () {
+    expect(StubStatus::Draft->getColor())->toBeNull();
+});
+
+it('satisfies Filament HasLabel and HasColor contracts', function () {
+    expect(StubStatus::Draft)->toBeInstanceOf(HasLabel::class);
+    expect(StubStatus::Draft)->toBeInstanceOf(HasColor::class);
+});
+
+it('lets the enum override getColor while keeping the default label', function () {
+    expect(StubColoredStatus::Approved->getColor())->toBe('success');
+    expect(StubColoredStatus::Pending->getColor())->toBe('warning');
+    expect(StubColoredStatus::Approved->getLabel())->toBe('Approved');
+});


### PR DESCRIPTION
## Summary

Adds two reusable concerns for downstream KurtModules packages.

### `Kurt\Modules\Core\Concerns\AbortsInProduction`
Trait for Artisan commands. `abortIfProduction()` prints an error and returns `true` when `getLaravel()->isProduction()` and no truthy `--force` was passed, so the caller returns `FAILURE`. Includes a `--force`-aware `isForced()` helper (safe on commands that do not declare the option). Designed to replace hand-rolled guards in downstream `*:demo` commands.

### `Kurt\Modules\Core\Concerns\HasEnumLabels`
Trait giving string-backed enums a Title-Case `getLabel()` (`InReview` -> "In Review") and a `null` `getColor()` default. Downstream enums declare Filament's `HasLabel`/`HasColor` contracts and `use` this trait for the method bodies, so **Core takes no hard dependency on Filament**. `getColor()` is overridable per case.

## Tests
- `AbortsInProduction`: local (runs), production (aborts, exit 1), production + `--force` (runs). Driven through a stub `Command` via real Symfony input/output with the app env flipped.
- `HasEnumLabels`: label derivation, null color default, per-case color override, and Filament `HasLabel`/`HasColor` contract compatibility.

## Notes
- `UserResolver` public contract unchanged.
- README updated with descriptions and usage examples.
- Gates: pint clean on changed files, phpstan level 8 clean, pest green (37 passed / 73 assertions, +7 new).