### PR TITLE
feat: shared API kit foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added
+- **API kit**: shared config-convention-driven REST foundation every module inherits.
+  - `Http\HttpMode` enum (`headless`/`api`/`ui`) with safe `forModule()` resolution.
+  - `Http\ApiRouteGroup` — builds `Route::group()` attributes from a module's `http` config.
+  - `Http\Controllers\ApiController` — abstract base with a consistent success/error envelope.
+  - `Http\Concerns\HandlesApiQuery` — allow-list-driven sorting, filtering and pagination.
+  - `Support\ApiRateLimiter` — registers the per-module `{slug}-api` throttle.
+  - `PackageServiceProvider::registerModuleApi()` — no-op in headless mode; wires the limiter and routes otherwise.
+
 ## [2.0.0] - 2026-05-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ composer require ozankurt/laravel-modules-core
 - `Kurt\Modules\Core\Support\FilamentVersion` — `::major()`, `::isAtLeast()`, `::isExactly()`.
 - `Kurt\Modules\Core\Enums\{Approval,MediaKind,Visibility}` — generic cross-module enums.
 - `Kurt\Modules\Core\Testing\PackageTestCase` — Testbench-backed base test case with an in-memory `users` table.
+- **API kit** — `Http\HttpMode`, `Http\ApiRouteGroup`, `Http\Controllers\ApiController`, `Http\Concerns\HandlesApiQuery`, `Support\ApiRateLimiter`, plus the `PackageServiceProvider::registerModuleApi()` hook. The config-convention-driven REST foundation every module inherits (see [API kit](#api-kit)).
 
 ## Configuration
 
@@ -92,6 +93,119 @@ enum Status: string implements HasColor, HasLabel
     }
 }
 ```
+
+## API kit
+
+A config-convention-driven foundation for a module's out-of-the-box REST API.
+It generalises the `loyalty.http.mode` pattern so every module exposes a JSON
+API the same way, **safe-by-default**: nothing is registered until a consumer
+opts in, and write routes require auth + a Policy.
+
+### Config convention
+
+Every consuming module reads these per-module keys (module slug = the value
+returned by the provider's `module()`):
+
+| Key | Default | Purpose |
+|---|---|---|
+| `{slug}.http.mode` | `headless` | `headless` \| `api` \| `ui`. API routes register only for `api`/`ui`. |
+| `{slug}.http.prefix` | `api/{slug}` | URL prefix for the route group. |
+| `{slug}.http.middleware` | `['api']` | Base middleware for every API route. |
+| `{slug}.http.auth_middleware` | `['auth']` | Appended to **write** (authenticated) routes. |
+| `{slug}.http.rate_limit` | `'60,1'` | `maxAttempts,decayMinutes` for the `{slug}-api` throttle. |
+
+Every group is throttled by a named limiter `{slug}-api` (keyed by user id, or
+client IP for guests). A module's `config/{slug}.php` therefore ships:
+
+```php
+'http' => [
+    'mode' => env('BLOG_HTTP_MODE', 'headless'),
+    'prefix' => 'api/blog',
+    'middleware' => ['api'],
+    'auth_middleware' => ['auth:sanctum'],
+    'rate_limit' => '60,1',
+],
+```
+
+### Base classes
+
+- `Http\HttpMode` — `HttpMode::forModule($slug)` resolves `{slug}.http.mode`
+  (unknown → `Headless`); `->apiEnabled()`, `->is(...)`.
+- `Http\ApiRouteGroup` — `ApiRouteGroup::attributes($slug, $authenticated = false)`
+  returns the `Route::group()` array (`prefix`, merged `middleware` + throttle
+  [+ `auth_middleware` when `$authenticated`], `as` = `"{slug}.api."`).
+- `Http\Controllers\ApiController` — abstract base (adds `AuthorizesRequests`,
+  `ValidatesRequests`) with a consistent envelope:
+  - `respond($data, array $meta = [], int $status = 200)` → `{ "data": …, "meta": … }` (`meta` omitted when empty).
+  - `respondCreated($data)` (201), `respondNoContent()` (204, empty body).
+  - `respondPaginated(LengthAwarePaginator $p, ?string $resourceClass = null)` → items as `data` (mapped through the resource class when given) + `meta.pagination` (`current_page`, `per_page`, `total`, `last_page`).
+  - `fail(string $message, int $status = 422, array $errors = [])` → `{ "message": …, "errors": … }`.
+- `Http\Concerns\HandlesApiQuery` — allow-list-driven query helpers (never
+  interpolate raw input as SQL identifiers):
+  - `applyApiSorts($q, $r, array $allowed)` — `?sort=field,-other` (leading `-` = desc); non-allowed fields dropped.
+  - `applyApiFilters($q, $r, array $allowed)` — `?filter[field]=value`; `$allowed` is a list of exact fields (`['name']`) or a mode map (`['name' => 'like', 'status' => 'exact']`). `like` → `%value%`.
+  - `apiPaginate($q, $r, int $default = 15, int $max = 100)` — `?per_page=` clamped to `[1, $max]`, standard `?page=`.
+- `Support\ApiRateLimiter` — `ApiRateLimiter::register($slug)` registers the
+  `{slug}-api` limiter from `{slug}.http.rate_limit`.
+
+### Resources vs envelope helpers
+
+The envelope's top-level key is `data`, matching Laravel API Resources. **Use
+Laravel resources directly** (Core ships no resource base) and hand the *result*
+of a resource to the envelope helpers so the payload is wrapped exactly once:
+
+```php
+// Single: pass the resource itself — nested resources are not re-wrapped.
+return $this->respond(PostResource::make($post));
+
+// Collection: map through the resource, then envelope.
+return $this->respondPaginated($paginator, PostResource::class);
+```
+
+Do **not** return a bare `JsonResource` from a route *and* also call `respond()`
+— that double-wraps as `{"data":{"data":…}}`.
+
+### How a module exposes an API
+
+1. **Config** — add the `http` block above to `config/{slug}.php`; keep
+   `mode` defaulting to `headless`.
+2. **Resources** — define `App`-style `JsonResource` classes for your models.
+3. **Controller** — extend `ApiController`; keep controllers thin over domain
+   services. `use HandlesApiQuery` on index controllers for sort/filter/paginate.
+   Enforce a **Policy** on every write (`$this->authorize(...)`).
+4. **Routes** — `routes/api.php`, read vs write split via
+   `ApiRouteGroup::attributes()`:
+
+   ```php
+   use Illuminate\Support\Facades\Route;
+
+   // Read (public) endpoints — base middleware + throttle.
+   Route::get('posts', [PostController::class, 'index'])->name('posts.index');
+   Route::get('posts/{post}', [PostController::class, 'show'])->name('posts.show');
+
+   // Write endpoints — add the module auth middleware.
+   Route::group(['middleware' => config('blog.http.auth_middleware', ['auth'])], function () {
+       Route::post('posts', [PostController::class, 'store'])->name('posts.store');
+       Route::patch('posts/{post}', [PostController::class, 'update'])->name('posts.update');
+       Route::delete('posts/{post}', [PostController::class, 'destroy'])->name('posts.destroy');
+   });
+   ```
+
+5. **Provider** — wire it in `packageBooted()`; it is a no-op in headless mode
+   and registers the rate limiter + route group otherwise:
+
+   ```php
+   public function packageBooted(): void
+   {
+       parent::packageBooted();
+
+       $this->registerModuleApi(__DIR__.'/../../routes/api.php');
+   }
+   ```
+
+The outer group (prefix, base middleware, throttle, `"{slug}.api."` name prefix)
+is applied by `registerModuleApi()`; the route file only distinguishes read vs
+write.
 
 ## License
 

--- a/src/Http/ApiRouteGroup.php
+++ b/src/Http/ApiRouteGroup.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Http;
+
+use Kurt\Modules\Core\Support\ApiRateLimiter;
+
+/**
+ * Builds the `Route::group(...)` attribute array for a module's REST API from
+ * its per-module `http` config block, applying safe defaults when keys are
+ * absent:
+ *
+ *   {slug}.http.prefix          default "api/{slug}"
+ *   {slug}.http.middleware      default ['api']
+ *   {slug}.http.auth_middleware default ['auth']  (appended to write routes)
+ *
+ * Read (public) routes get the base middleware plus the module throttle;
+ * write routes additionally get the auth middleware. Every group is throttled
+ * by the named limiter "{slug}-api" (see {@see ApiRateLimiter}).
+ */
+final class ApiRouteGroup
+{
+    /**
+     * @return array{prefix: string, middleware: array<int, string>, as: string}
+     */
+    public static function attributes(string $slug, bool $authenticated = false): array
+    {
+        return [
+            'prefix' => self::prefix($slug),
+            'middleware' => self::middleware($slug, $authenticated),
+            'as' => "{$slug}.api.",
+        ];
+    }
+
+    private static function prefix(string $slug): string
+    {
+        $prefix = config("{$slug}.http.prefix", "api/{$slug}");
+
+        return is_string($prefix) ? $prefix : "api/{$slug}";
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function middleware(string $slug, bool $authenticated): array
+    {
+        $middleware = self::stringList(config("{$slug}.http.middleware", ['api']));
+
+        if ($authenticated) {
+            $middleware = array_merge(
+                $middleware,
+                self::stringList(config("{$slug}.http.auth_middleware", ['auth'])),
+            );
+        }
+
+        // Throttle last so it runs after any auth middleware has resolved the
+        // user the limiter keys on.
+        $middleware[] = "throttle:{$slug}-api";
+
+        return array_values($middleware);
+    }
+
+    /**
+     * Normalise a config value into a list of middleware strings. Accepts a
+     * single string or an array; anything else falls back to an empty list.
+     *
+     * @return array<int, string>
+     */
+    private static function stringList(mixed $value): array
+    {
+        if (is_string($value)) {
+            return [$value];
+        }
+
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, 'is_string'));
+    }
+}

--- a/src/Http/Concerns/HandlesApiQuery.php
+++ b/src/Http/Concerns/HandlesApiQuery.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Http\Concerns;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+
+/**
+ * Query-string helpers for module REST index endpoints: sorting, filtering and
+ * pagination driven by request params.
+ *
+ * Every helper is allow-list driven and never interpolates raw request input as
+ * a SQL identifier: only column names the caller explicitly permits reach the
+ * query builder, so unknown or hostile params are silently dropped rather than
+ * trusted.
+ */
+trait HandlesApiQuery
+{
+    /**
+     * Apply `?sort=field,-other` ordering.
+     *
+     * A leading `-` means descending. Only fields present in `$allowed` are
+     * applied; everything else is dropped silently.
+     *
+     * @param  Builder<covariant Model>  $query
+     * @param  array<int, string>  $allowed
+     * @return Builder<covariant Model>
+     */
+    protected function applyApiSorts(Builder $query, Request $request, array $allowed): Builder
+    {
+        $sort = $request->query('sort');
+
+        if (! is_string($sort) || $sort === '') {
+            return $query;
+        }
+
+        foreach (explode(',', $sort) as $field) {
+            $field = trim($field);
+            $direction = 'asc';
+
+            if (str_starts_with($field, '-')) {
+                $direction = 'desc';
+                $field = substr($field, 1);
+            }
+
+            if ($field === '' || ! in_array($field, $allowed, true)) {
+                continue;
+            }
+
+            $query->orderBy($field, $direction);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Apply `?filter[field]=value` constraints.
+     *
+     * `$allowed` may be a plain list of exact-match fields (`['name', 'slug']`)
+     * or an assoc map marking each field `'exact'` or `'like'`
+     * (`['name' => 'like', 'status' => 'exact']`). `like` fields match
+     * `%value%`; everything else is an exact match. Fields not in the allow-list
+     * and non-scalar values are dropped silently.
+     *
+     * @param  Builder<covariant Model>  $query
+     * @param  array<int|string, string>  $allowed
+     * @return Builder<covariant Model>
+     */
+    protected function applyApiFilters(Builder $query, Request $request, array $allowed): Builder
+    {
+        $filters = $request->query('filter');
+
+        if (! is_array($filters)) {
+            return $query;
+        }
+
+        $modes = $this->normaliseFilterAllowList($allowed);
+
+        foreach ($filters as $field => $value) {
+            if (! is_string($field) || ! array_key_exists($field, $modes) || ! is_scalar($value)) {
+                continue;
+            }
+
+            $value = (string) $value;
+
+            if ($modes[$field] === 'like') {
+                $query->where($field, 'like', '%'.$value.'%');
+            } else {
+                $query->where($field, '=', $value);
+            }
+        }
+
+        return $query;
+    }
+
+    /**
+     * Paginate with a clamped `?per_page=` (bounded to [1, $max], defaulting to
+     * $default) and the standard `?page=` param.
+     *
+     * @param  Builder<covariant Model>  $query
+     * @return LengthAwarePaginator<int, Model>
+     */
+    protected function apiPaginate(Builder $query, Request $request, int $default = 15, int $max = 100): LengthAwarePaginator
+    {
+        $perPage = $request->query('per_page');
+        $perPage = is_numeric($perPage) ? (int) $perPage : $default;
+        $perPage = max(1, min($perPage, $max));
+
+        return $query->paginate($perPage);
+    }
+
+    /**
+     * Normalise the filter allow-list into a `[field => 'exact'|'like']` map,
+     * accepting either a plain list of field names or an assoc mode map.
+     *
+     * @param  array<int|string, string>  $allowed
+     * @return array<string, string>
+     */
+    private function normaliseFilterAllowList(array $allowed): array
+    {
+        $modes = [];
+
+        foreach ($allowed as $key => $value) {
+            if (is_int($key)) {
+                $modes[$value] = 'exact';
+
+                continue;
+            }
+
+            $modes[$key] = $value === 'like' ? 'like' : 'exact';
+        }
+
+        return $modes;
+    }
+}

--- a/src/Http/Controllers/ApiController.php
+++ b/src/Http/Controllers/ApiController.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Http\Controllers;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Routing\Controller;
+
+/**
+ * Base controller for module REST APIs.
+ *
+ * Provides a consistent success/error envelope and the standard
+ * authorization/validation traits so module controllers stay thin over their
+ * domain services.
+ *
+ * Envelope conventions:
+ *   success: { "data": <payload>, "meta": <object, omitted when empty> }
+ *   error:   { "message": <string>, "errors": <object> }
+ *
+ * The envelope shape mirrors Laravel API Resources, whose top-level key is also
+ * `data`. To avoid a doubly-wrapped `{"data":{"data":...}}` payload, pass the
+ * *result* of a resource (e.g. `UserResource::make($user)`) — never leave
+ * `JsonResource::$wrap` at its `data` default and also call {@see respond()}.
+ * These helpers add the single `data` wrapper; hand them the resource itself.
+ */
+abstract class ApiController extends Controller
+{
+    use AuthorizesRequests;
+    use ValidatesRequests;
+
+    /**
+     * Success envelope: `{ "data": ..., "meta": ... }`. The `meta` key is
+     * omitted entirely when empty.
+     *
+     * @param  array<string, mixed>  $meta
+     */
+    protected function respond(mixed $data, array $meta = [], int $status = 200): JsonResponse
+    {
+        $payload = ['data' => $data];
+
+        if ($meta !== []) {
+            $payload['meta'] = $meta;
+        }
+
+        return response()->json($payload, $status);
+    }
+
+    /**
+     * 201 Created success envelope.
+     */
+    protected function respondCreated(mixed $data): JsonResponse
+    {
+        return $this->respond($data, [], 201);
+    }
+
+    /**
+     * 204 No Content, with a genuinely empty body (a bare `response()->json()`
+     * would encode `null` as `{}`, which is invalid for a 204).
+     */
+    protected function respondNoContent(): JsonResponse
+    {
+        $response = new JsonResponse(null, 204);
+        $response->setContent('');
+
+        return $response;
+    }
+
+    /**
+     * Envelope a length-aware paginator: the items become `data`, and
+     * `meta.pagination` carries current_page / per_page / total / last_page.
+     *
+     * When a JsonResource class is given, each item is mapped through it so the
+     * paginated payload matches the module's resource shape.
+     *
+     * @param  LengthAwarePaginator<int, mixed>  $paginator
+     * @param  class-string<JsonResource>|null  $resourceClass
+     */
+    protected function respondPaginated(LengthAwarePaginator $paginator, ?string $resourceClass = null): JsonResponse
+    {
+        $items = $paginator->items();
+
+        $data = $resourceClass !== null
+            ? $resourceClass::collection($items)
+            : $items;
+
+        return $this->respond($data, [
+            'pagination' => [
+                'current_page' => $paginator->currentPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+                'last_page' => $paginator->lastPage(),
+            ],
+        ]);
+    }
+
+    /**
+     * Error envelope: `{ "message": ..., "errors": ... }`. Defaults to 422 to
+     * match Laravel's validation-error status.
+     *
+     * @param  array<string, mixed>  $errors
+     */
+    protected function fail(string $message, int $status = 422, array $errors = []): JsonResponse
+    {
+        return response()->json([
+            'message' => $message,
+            'errors' => $errors,
+        ], $status);
+    }
+}

--- a/src/Http/HttpMode.php
+++ b/src/Http/HttpMode.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Http;
+
+/**
+ * How much of a module's HTTP surface is exposed.
+ *
+ *   headless - nothing is registered; call the module's domain services yourself.
+ *   api      - JSON REST endpoints are registered.
+ *   ui       - everything in `api` plus any shipped HTML pages / Filament panels.
+ *
+ * Modules are safe-by-default: absent (or invalid) config resolves to Headless,
+ * so no routes are registered until a consumer opts in.
+ */
+enum HttpMode: string
+{
+    case Headless = 'headless';
+    case Api = 'api';
+    case Ui = 'ui';
+
+    /**
+     * Resolve the mode for a module from `config("{slug}.http.mode")`.
+     *
+     * Unknown or non-string values resolve to {@see self::Headless} so a
+     * mis-configured module never accidentally exposes its routes.
+     */
+    public static function forModule(string $slug): self
+    {
+        $value = config("{$slug}.http.mode", self::Headless->value);
+
+        if (! is_string($value)) {
+            return self::Headless;
+        }
+
+        return self::tryFrom($value) ?? self::Headless;
+    }
+
+    /**
+     * Whether the JSON API surface should be registered. True for Api and Ui;
+     * UI is a superset of API.
+     */
+    public function apiEnabled(): bool
+    {
+        return $this === self::Api || $this === self::Ui;
+    }
+
+    /**
+     * Whether this mode is any of the given modes.
+     */
+    public function is(self ...$modes): bool
+    {
+        return in_array($this, $modes, true);
+    }
+}

--- a/src/Providers/PackageServiceProvider.php
+++ b/src/Providers/PackageServiceProvider.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Kurt\Modules\Core\Providers;
 
+use Illuminate\Support\Facades\Route;
+use Kurt\Modules\Core\Http\ApiRouteGroup;
+use Kurt\Modules\Core\Http\HttpMode;
+use Kurt\Modules\Core\Support\ApiRateLimiter;
 use Kurt\Modules\Core\Support\FilamentVersion;
 use Spatie\LaravelPackageTools\PackageServiceProvider as BasePackageServiceProvider;
 
@@ -41,6 +45,42 @@ abstract class PackageServiceProvider extends BasePackageServiceProvider
     final protected function configKey(string $key): string
     {
         return "{$this->module()}.{$key}";
+    }
+
+    /**
+     * Register the module's REST API surface, gated by `{module}.http.mode`.
+     *
+     * A no-op in headless mode. When the API is enabled (api or ui) this
+     * registers the module's named rate limiter and, unless routes are cached,
+     * loads the given routes file inside a `Route::group()` built from the
+     * module's `http` config (prefix, middleware, throttle, name prefix).
+     *
+     * Modules call this from packageBooted():
+     *
+     *   $this->registerModuleApi(__DIR__.'/../../routes/api.php');
+     *
+     * The routes file distinguishes read vs write endpoints itself, applying
+     * the module's auth middleware to writes (e.g. via
+     * {@see ApiRouteGroup::attributes()} with `authenticated: true`, or a
+     * per-route `->middleware(config('{slug}.http.auth_middleware'))`).
+     */
+    protected function registerModuleApi(string $routesFile): void
+    {
+        if (! HttpMode::forModule($this->module())->apiEnabled()) {
+            return;
+        }
+
+        // The limiter must be registered even when routes are cached: the
+        // throttle middleware resolves it by name at request time.
+        ApiRateLimiter::register($this->module());
+
+        if ($this->app->routesAreCached()) {
+            return;
+        }
+
+        Route::group(ApiRouteGroup::attributes($this->module()), function () use ($routesFile): void {
+            require $routesFile;
+        });
     }
 
     /**

--- a/src/Support/ApiRateLimiter.php
+++ b/src/Support/ApiRateLimiter.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Support;
+
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Kurt\Modules\Core\Http\ApiRouteGroup;
+
+/**
+ * Registers the named rate limiter that a module's API routes throttle against.
+ *
+ * The limiter is named "{slug}-api" (referenced as `throttle:{slug}-api` in
+ * {@see ApiRouteGroup}) and reads its budget from
+ * `config("{slug}.http.rate_limit")` in "maxAttempts,decayMinutes" form
+ * (default "60,1"). Requests are keyed by authenticated user id, falling back
+ * to client IP for guests.
+ */
+final class ApiRateLimiter
+{
+    /**
+     * Register the "{slug}-api" limiter. Safe to call whenever a module's API
+     * surface boots; re-registering simply overwrites the callback.
+     */
+    public static function register(string $slug): void
+    {
+        [$maxAttempts, $decayMinutes] = self::parse(config("{$slug}.http.rate_limit", '60,1'));
+
+        RateLimiter::for("{$slug}-api", function (Request $request) use ($maxAttempts, $decayMinutes): Limit {
+            $key = $request->user()?->getAuthIdentifier() ?? $request->ip() ?? 'unknown';
+
+            return Limit::perMinutes($decayMinutes, $maxAttempts)->by((string) $key);
+        });
+    }
+
+    /**
+     * Parse a "maxAttempts,decayMinutes" string into ints, falling back to
+     * 60 attempts / 1 minute for any missing or non-numeric part.
+     *
+     * @return array{0: int, 1: int}
+     */
+    private static function parse(mixed $rateLimit): array
+    {
+        $parts = is_string($rateLimit) ? explode(',', $rateLimit) : [];
+
+        $maxAttempts = isset($parts[0]) && is_numeric(trim($parts[0])) ? (int) trim($parts[0]) : 60;
+        $decayMinutes = isset($parts[1]) && is_numeric(trim($parts[1])) ? (int) trim($parts[1]) : 1;
+
+        return [max(1, $maxAttempts), max(1, $decayMinutes)];
+    }
+}

--- a/tests/Feature/Http/ApiControllerTest.php
+++ b/tests/Feature/Http/ApiControllerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Kurt\Modules\Core\Http\Controllers\ApiController;
+use Kurt\Modules\Core\Tests\Stubs\StubApiRecord;
+use Kurt\Modules\Core\Tests\Stubs\StubApiResource;
+
+/**
+ * Anonymous controller exposing the protected envelope helpers.
+ */
+function apiControllerHarness(): ApiController
+{
+    return new class extends ApiController
+    {
+        /** @param  array<string, mixed>  $meta */
+        public function doRespond(mixed $data, array $meta = [], int $status = 200): JsonResponse
+        {
+            return $this->respond($data, $meta, $status);
+        }
+
+        public function doCreated(mixed $data): JsonResponse
+        {
+            return $this->respondCreated($data);
+        }
+
+        public function doNoContent(): JsonResponse
+        {
+            return $this->respondNoContent();
+        }
+
+        /**
+         * @param  LengthAwarePaginator<int, mixed>  $paginator
+         * @param  class-string<JsonResource>|null  $resourceClass
+         */
+        public function doPaginated(LengthAwarePaginator $paginator, ?string $resourceClass = null): JsonResponse
+        {
+            return $this->respondPaginated($paginator, $resourceClass);
+        }
+
+        /** @param  array<string, mixed>  $errors */
+        public function doFail(string $message, int $status = 422, array $errors = []): JsonResponse
+        {
+            return $this->fail($message, $status, $errors);
+        }
+    };
+}
+
+it('wraps data in a data key and omits empty meta', function () {
+    $response = apiControllerHarness()->doRespond(['id' => 1]);
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and($response->getData(true))->toBe(['data' => ['id' => 1]]);
+});
+
+it('includes meta when provided', function () {
+    $response = apiControllerHarness()->doRespond(['id' => 1], ['total' => 5]);
+
+    expect($response->getData(true))->toBe([
+        'data' => ['id' => 1],
+        'meta' => ['total' => 5],
+    ]);
+});
+
+it('respondCreated returns 201', function () {
+    $response = apiControllerHarness()->doCreated(['id' => 9]);
+
+    expect($response->getStatusCode())->toBe(201)
+        ->and($response->getData(true))->toBe(['data' => ['id' => 9]]);
+});
+
+it('respondNoContent returns 204 with an empty body', function () {
+    $response = apiControllerHarness()->doNoContent();
+
+    expect($response->getStatusCode())->toBe(204)
+        ->and($response->getContent())->toBe('');
+});
+
+it('paginated envelope carries pagination meta', function () {
+    $paginator = new LengthAwarePaginator([['id' => 1], ['id' => 2]], total: 12, perPage: 5, currentPage: 2);
+
+    $response = apiControllerHarness()->doPaginated($paginator);
+
+    expect($response->getData(true))->toBe([
+        'data' => [['id' => 1], ['id' => 2]],
+        'meta' => [
+            'pagination' => [
+                'current_page' => 2,
+                'per_page' => 5,
+                'total' => 12,
+                'last_page' => 3,
+            ],
+        ],
+    ]);
+});
+
+it('maps paginated items through a resource class', function () {
+    $items = [
+        new StubApiRecord(['id' => 1, 'name' => 'apple']),
+        new StubApiRecord(['id' => 2, 'name' => 'banana']),
+    ];
+    $paginator = new LengthAwarePaginator($items, total: 2, perPage: 15, currentPage: 1);
+
+    $response = apiControllerHarness()->doPaginated($paginator, StubApiResource::class);
+
+    expect($response->getData(true)['data'])->toBe([
+        ['id' => 1, 'name' => 'apple'],
+        ['id' => 2, 'name' => 'banana'],
+    ]);
+});
+
+it('fail returns the error envelope with a 422 default', function () {
+    $response = apiControllerHarness()->doFail('Invalid.');
+
+    expect($response->getStatusCode())->toBe(422)
+        ->and($response->getData(true))->toBe([
+            'message' => 'Invalid.',
+            'errors' => [],
+        ]);
+});
+
+it('fail honours a custom status and errors', function () {
+    $response = apiControllerHarness()->doFail('Nope.', 403, ['field' => ['bad']]);
+
+    expect($response->getStatusCode())->toBe(403)
+        ->and($response->getData(true))->toBe([
+            'message' => 'Nope.',
+            'errors' => ['field' => ['bad']],
+        ]);
+});

--- a/tests/Feature/Http/ApiRouteGroupTest.php
+++ b/tests/Feature/Http/ApiRouteGroupTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Core\Http\ApiRouteGroup;
+
+it('builds default attributes when no config is set', function () {
+    $attributes = ApiRouteGroup::attributes('demo');
+
+    expect($attributes['prefix'])->toBe('api/demo')
+        ->and($attributes['as'])->toBe('demo.api.')
+        ->and($attributes['middleware'])->toBe(['api', 'throttle:demo-api']);
+});
+
+it('honours a custom prefix and middleware', function () {
+    config()->set('demo.http.prefix', 'v1/demo');
+    config()->set('demo.http.middleware', ['api', 'json.force']);
+
+    $attributes = ApiRouteGroup::attributes('demo');
+
+    expect($attributes['prefix'])->toBe('v1/demo')
+        ->and($attributes['middleware'])->toBe(['api', 'json.force', 'throttle:demo-api']);
+});
+
+it('appends auth middleware for authenticated (write) groups', function () {
+    $attributes = ApiRouteGroup::attributes('demo', authenticated: true);
+
+    expect($attributes['middleware'])->toBe(['api', 'auth', 'throttle:demo-api']);
+});
+
+it('appends custom auth middleware before the throttle', function () {
+    config()->set('demo.http.middleware', ['api']);
+    config()->set('demo.http.auth_middleware', ['auth:sanctum', 'verified']);
+
+    $attributes = ApiRouteGroup::attributes('demo', authenticated: true);
+
+    expect($attributes['middleware'])->toBe(['api', 'auth:sanctum', 'verified', 'throttle:demo-api']);
+});
+
+it('accepts a single string middleware value', function () {
+    config()->set('demo.http.middleware', 'api');
+
+    $attributes = ApiRouteGroup::attributes('demo');
+
+    expect($attributes['middleware'])->toBe(['api', 'throttle:demo-api']);
+});
+
+it('always throttles even with empty base middleware', function () {
+    config()->set('demo.http.middleware', []);
+
+    $attributes = ApiRouteGroup::attributes('demo');
+
+    expect($attributes['middleware'])->toBe(['throttle:demo-api']);
+});

--- a/tests/Feature/Http/HandlesApiQueryTest.php
+++ b/tests/Feature/Http/HandlesApiQueryTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use Kurt\Modules\Core\Http\Concerns\HandlesApiQuery;
+use Kurt\Modules\Core\Tests\Stubs\StubApiRecord;
+
+/**
+ * Exposes the protected HandlesApiQuery helpers for assertion.
+ */
+function apiQueryHarness(): object
+{
+    return new class
+    {
+        use HandlesApiQuery;
+
+        /**
+         * @param  Builder<StubApiRecord>  $query
+         * @param  array<int, string>  $allowed
+         * @return Builder<StubApiRecord>
+         */
+        public function sorts(Builder $query, Request $request, array $allowed): Builder
+        {
+            return $this->applyApiSorts($query, $request, $allowed);
+        }
+
+        /**
+         * @param  Builder<StubApiRecord>  $query
+         * @param  array<int|string, string>  $allowed
+         * @return Builder<StubApiRecord>
+         */
+        public function filters(Builder $query, Request $request, array $allowed): Builder
+        {
+            return $this->applyApiFilters($query, $request, $allowed);
+        }
+
+        /**
+         * @param  Builder<StubApiRecord>  $query
+         */
+        public function paginate(Builder $query, Request $request, int $default = 15, int $max = 100): mixed
+        {
+            return $this->apiPaginate($query, $request, $default, $max);
+        }
+    };
+}
+
+beforeEach(function () {
+    Schema::create('stub_api_records', function (Blueprint $table) {
+        $table->id();
+        $table->string('name');
+        $table->string('status')->default('active');
+    });
+
+    foreach (['banana', 'apple', 'cherry'] as $i => $name) {
+        StubApiRecord::create(['name' => $name, 'status' => $i === 0 ? 'draft' : 'active']);
+    }
+});
+
+afterEach(function () {
+    Schema::dropIfExists('stub_api_records');
+});
+
+it('applies an ascending sort on an allow-listed field', function () {
+    $request = Request::create('/', 'GET', ['sort' => 'name']);
+
+    $names = apiQueryHarness()->sorts(StubApiRecord::query(), $request, ['name'])->pluck('name')->all();
+
+    expect($names)->toBe(['apple', 'banana', 'cherry']);
+});
+
+it('applies a descending sort with a leading minus', function () {
+    $request = Request::create('/', 'GET', ['sort' => '-name']);
+
+    $names = apiQueryHarness()->sorts(StubApiRecord::query(), $request, ['name'])->pluck('name')->all();
+
+    expect($names)->toBe(['cherry', 'banana', 'apple']);
+});
+
+it('drops sort fields that are not allow-listed', function () {
+    $request = Request::create('/', 'GET', ['sort' => 'name,-secret']);
+
+    $query = apiQueryHarness()->sorts(StubApiRecord::query(), $request, ['name']);
+
+    // Only the allow-listed `name` order should reach the query.
+    expect($query->getQuery()->orders)->toBe([
+        ['column' => 'name', 'direction' => 'asc'],
+    ]);
+});
+
+it('is a no-op when no sort param is present', function () {
+    $query = apiQueryHarness()->sorts(StubApiRecord::query(), Request::create('/'), ['name']);
+
+    expect($query->getQuery()->orders)->toBeNull();
+});
+
+it('applies an exact filter on an allow-listed field', function () {
+    $request = Request::create('/', 'GET', ['filter' => ['status' => 'draft']]);
+
+    $records = apiQueryHarness()->filters(StubApiRecord::query(), $request, ['status'])->pluck('name')->all();
+
+    expect($records)->toBe(['banana']);
+});
+
+it('applies a like filter when the field is marked like', function () {
+    $request = Request::create('/', 'GET', ['filter' => ['name' => 'err']]);
+
+    $records = apiQueryHarness()->filters(StubApiRecord::query(), $request, ['name' => 'like'])->pluck('name')->all();
+
+    expect($records)->toBe(['cherry']);
+});
+
+it('drops filters that are not allow-listed', function () {
+    $request = Request::create('/', 'GET', ['filter' => ['status' => 'draft', 'name' => 'apple']]);
+
+    // Only `status` is permitted; the `name` constraint must be ignored.
+    $records = apiQueryHarness()->filters(StubApiRecord::query(), $request, ['status'])->pluck('name')->all();
+
+    expect($records)->toBe(['banana']);
+});
+
+it('ignores non-scalar filter values', function () {
+    $request = Request::create('/', 'GET', ['filter' => ['status' => ['draft']]]);
+
+    $records = apiQueryHarness()->filters(StubApiRecord::query(), $request, ['status'])->pluck('name')->all();
+
+    expect($records)->toHaveCount(3);
+});
+
+it('paginates with the default per_page', function () {
+    $paginator = apiQueryHarness()->paginate(StubApiRecord::query(), Request::create('/'), default: 2);
+
+    expect($paginator->perPage())->toBe(2)
+        ->and($paginator->total())->toBe(3)
+        ->and($paginator->lastPage())->toBe(2);
+});
+
+it('clamps per_page to the max', function () {
+    $request = Request::create('/', 'GET', ['per_page' => '999']);
+
+    $paginator = apiQueryHarness()->paginate(StubApiRecord::query(), $request, max: 25);
+
+    expect($paginator->perPage())->toBe(25);
+});
+
+it('clamps per_page to a minimum of one', function () {
+    $request = Request::create('/', 'GET', ['per_page' => '0']);
+
+    $paginator = apiQueryHarness()->paginate(StubApiRecord::query(), $request);
+
+    expect($paginator->perPage())->toBe(1);
+});
+
+it('falls back to the default for a non-numeric per_page', function () {
+    $request = Request::create('/', 'GET', ['per_page' => 'lots']);
+
+    $paginator = apiQueryHarness()->paginate(StubApiRecord::query(), $request, default: 7);
+
+    expect($paginator->perPage())->toBe(7);
+});

--- a/tests/Feature/Http/HttpModeTest.php
+++ b/tests/Feature/Http/HttpModeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Core\Http\HttpMode;
+
+it('defaults to headless when no config is set', function () {
+    expect(HttpMode::forModule('demo'))->toBe(HttpMode::Headless);
+});
+
+it('resolves each configured mode', function (string $value, HttpMode $expected) {
+    config()->set('demo.http.mode', $value);
+
+    expect(HttpMode::forModule('demo'))->toBe($expected);
+})->with([
+    ['headless', HttpMode::Headless],
+    ['api', HttpMode::Api],
+    ['ui', HttpMode::Ui],
+]);
+
+it('falls back to headless for an unknown mode', function () {
+    config()->set('demo.http.mode', 'nonsense');
+
+    expect(HttpMode::forModule('demo'))->toBe(HttpMode::Headless);
+});
+
+it('falls back to headless for a non-string mode', function () {
+    config()->set('demo.http.mode', ['api']);
+
+    expect(HttpMode::forModule('demo'))->toBe(HttpMode::Headless);
+});
+
+it('reports apiEnabled for api and ui only', function () {
+    expect(HttpMode::Headless->apiEnabled())->toBeFalse()
+        ->and(HttpMode::Api->apiEnabled())->toBeTrue()
+        ->and(HttpMode::Ui->apiEnabled())->toBeTrue();
+});
+
+it('matches modes via is()', function () {
+    expect(HttpMode::Api->is(HttpMode::Api, HttpMode::Ui))->toBeTrue()
+        ->and(HttpMode::Headless->is(HttpMode::Api, HttpMode::Ui))->toBeFalse();
+});

--- a/tests/Feature/RegisterModuleApiTest.php
+++ b/tests/Feature/RegisterModuleApiTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Route;
+use Kurt\Modules\Core\Providers\PackageServiceProvider;
+use Spatie\LaravelPackageTools\Package;
+
+/**
+ * Provider exposing the protected registerModuleApi() hook for the fixed
+ * `demo` module slug.
+ */
+function moduleApiProvider(): PackageServiceProvider
+{
+    return new class(app()) extends PackageServiceProvider
+    {
+        protected function module(): string
+        {
+            return 'demo';
+        }
+
+        public function configurePackage(Package $package): void
+        {
+            $package->name('demo');
+        }
+
+        public function callRegisterModuleApi(string $file): void
+        {
+            $this->registerModuleApi($file);
+        }
+    };
+}
+
+$routesFile = fn () => __DIR__.'/../Stubs/stub-api-routes.php';
+
+it('is a no-op in headless mode', function () use ($routesFile) {
+    moduleApiProvider()->callRegisterModuleApi($routesFile());
+    Route::getRoutes()->refreshNameLookups();
+
+    expect(Route::has('demo.api.ping'))->toBeFalse()
+        ->and(RateLimiter::limiter('demo-api'))->toBeNull();
+});
+
+it('registers the throttle limiter and routes in api mode', function () use ($routesFile) {
+    config()->set('demo.http.mode', 'api');
+
+    moduleApiProvider()->callRegisterModuleApi($routesFile());
+    // The framework refreshes name lookups after the boot phase; do it here so
+    // the manually-invoked hook is observable in-test.
+    Route::getRoutes()->refreshNameLookups();
+
+    expect(RateLimiter::limiter('demo-api'))->not->toBeNull()
+        ->and(Route::has('demo.api.ping'))->toBeTrue();
+
+    $route = Route::getRoutes()->getByName('demo.api.ping');
+    expect($route->uri())->toBe('api/demo/ping')
+        ->and($route->gatherMiddleware())->toBe(['api', 'throttle:demo-api']);
+});
+
+it('enables the api surface in ui mode', function () use ($routesFile) {
+    config()->set('demo.http.mode', 'ui');
+
+    moduleApiProvider()->callRegisterModuleApi($routesFile());
+
+    // UI is a superset of API, so the module rate limiter is registered just as
+    // it is for api mode (route file loading shares the same code path).
+    expect(RateLimiter::limiter('demo-api'))->not->toBeNull();
+});

--- a/tests/Feature/Support/ApiRateLimiterTest.php
+++ b/tests/Feature/Support/ApiRateLimiterTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Kurt\Modules\Core\Support\ApiRateLimiter;
+
+it('registers a named limiter from config', function () {
+    config()->set('demo.http.rate_limit', '10,2');
+
+    ApiRateLimiter::register('demo');
+
+    $limiter = RateLimiter::limiter('demo-api');
+    expect($limiter)->not->toBeNull();
+
+    $limit = $limiter(Request::create('/'));
+    expect($limit)->toBeInstanceOf(Limit::class)
+        ->and($limit->maxAttempts)->toBe(10)
+        ->and($limit->decaySeconds)->toBe(120);
+});
+
+it('defaults to 60 attempts per minute when config is missing', function () {
+    ApiRateLimiter::register('nodef');
+
+    $limit = RateLimiter::limiter('nodef-api')(Request::create('/'));
+
+    expect($limit->maxAttempts)->toBe(60)
+        ->and($limit->decaySeconds)->toBe(60);
+});
+
+it('keys guests by ip address', function () {
+    ApiRateLimiter::register('demo');
+
+    $limit = RateLimiter::limiter('demo-api')(Request::create('/', 'GET', server: ['REMOTE_ADDR' => '10.0.0.9']));
+
+    expect($limit->key)->toBe('10.0.0.9');
+});
+
+it('keys authenticated requests by user identifier', function () {
+    ApiRateLimiter::register('demo');
+
+    $request = Request::create('/');
+    $request->setUserResolver(fn () => new class
+    {
+        public function getAuthIdentifier(): int
+        {
+            return 42;
+        }
+    });
+
+    $limit = RateLimiter::limiter('demo-api')($request);
+
+    expect($limit->key)->toBe('42');
+});
+
+it('falls back to defaults for a malformed rate_limit string', function () {
+    config()->set('demo.http.rate_limit', 'garbage');
+
+    ApiRateLimiter::register('demo');
+
+    $limit = RateLimiter::limiter('demo-api')(Request::create('/'));
+
+    expect($limit->maxAttempts)->toBe(60)
+        ->and($limit->decaySeconds)->toBe(60);
+});

--- a/tests/Stubs/StubApiRecord.php
+++ b/tests/Stubs/StubApiRecord.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Tests\Stubs;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Minimal Eloquent model backing the HandlesApiQuery / pagination tests.
+ *
+ * @property int $id
+ * @property string $name
+ * @property string $status
+ */
+class StubApiRecord extends Model
+{
+    protected $table = 'stub_api_records';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+}

--- a/tests/Stubs/StubApiResource.php
+++ b/tests/Stubs/StubApiResource.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Tests\Stubs;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Resource used to assert respondPaginated() maps items through a resource class.
+ */
+class StubApiResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->id,
+            'name' => $this->resource->name,
+        ];
+    }
+}

--- a/tests/Stubs/stub-api-routes.php
+++ b/tests/Stubs/stub-api-routes.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('ping', fn () => 'pong')->name('ping');


### PR DESCRIPTION
## Summary

Adds the shared **API kit** to Core — the config-convention-driven REST foundation every KurtModules module inherits for its out-of-the-box JSON API. Generalises the `loyalty.http.mode` pattern (headless/api/ui, thin controllers over domain services, mode-gated route registration) so all 10 modules reuse one base. Additive; targets **v2.2.0**.

**Safe-by-default:** nothing registers until a module opts in via `{slug}.http.mode` (default `headless`); write routes require `auth_middleware` + a Policy; query helpers are allow-list-driven and never interpolate raw input as SQL identifiers.

## Config convention (per-module, slug = provider `module()`)

| Key | Default |
|---|---|
| `{slug}.http.mode` | `headless` (`headless`\|`api`\|`ui`) |
| `{slug}.http.prefix` | `api/{slug}` |
| `{slug}.http.middleware` | `['api']` |
| `{slug}.http.auth_middleware` | `['auth']` (write routes) |
| `{slug}.http.rate_limit` | `'60,1'` (maxAttempts,decayMinutes) |

## Public API surface

- `Http\HttpMode` (enum): `forModule(string $slug): self`, `apiEnabled(): bool`, `is(self ...$modes): bool`
- `Http\ApiRouteGroup`: `static attributes(string $slug, bool $authenticated = false): array`
- `Http\Controllers\ApiController` (abstract): `respond`, `respondCreated`, `respondNoContent`, `respondPaginated`, `fail`
- `Http\Concerns\HandlesApiQuery` (trait): `applyApiSorts`, `applyApiFilters`, `apiPaginate`
- `Support\ApiRateLimiter`: `static register(string $slug): void`
- `PackageServiceProvider::registerModuleApi(string $routesFile): void` (protected hook)

## Docs

README gains an **API kit** section: config keys, base classes, resources-vs-envelope guidance, and a "how a module exposes an API" recipe.

## Tests

79 pest tests (137 assertions) green. Covers HttpMode resolution/defaults, ApiRouteGroup attributes (defaults, custom prefix/middleware, authenticated merge, always-throttle), HandlesApiQuery sort/filter allow-listing + per_page clamping, ApiController envelopes, ApiRateLimiter registration/keying/defaults, and the provider hook (headless no-op vs api/ui).

## Gates

- pint: clean on changed files
- phpstan: level 8, no errors
- pest: 79 passed (coverage unavailable locally; verified with plain pest per house rules)