### PR TITLE
Module Management M1: core manifest & registry

### DIFF
--- a/docs/superpowers/plans/2026-07-23-module-management-m1-core-registry.md
+++ b/docs/superpowers/plans/2026-07-23-module-management-m1-core-registry.md
@@ -1,0 +1,601 @@
+# Module Management M1 - Core Manifest & Registry - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a module self-declaration mechanism to `laravel-modules-core`: a `ModuleManifest` value object each module declares, collected at boot into an in-memory `ModuleRegistry`. No DB, no API - that is M2/M3.
+
+**Architecture:** A fluent `ModuleManifest` value object (slug, name, version, description, dependencies, feature defaults, setting defaults, enabled-by-default). A `ModuleRegistry` contract with an in-memory `Registry` implementation, bound as a singleton by `CoreServiceProvider`. The base `PackageServiceProvider` gains a `moduleManifest()` hook (default `null`); during `packageBooted()` it registers a non-null manifest into the registry. Modules opt in by overriding `moduleManifest()`.
+
+**Tech Stack:** PHP 8.4, Laravel 12 (`illuminate/*` ^12), `spatie/laravel-package-tools`, Pest 3 + Orchestra Testbench, on top of the existing core package.
+
+## Global Constraints
+
+- Package: `ozankurt/laravel-modules-core`, namespace `Kurt\Modules\Core\`, repo `OzanKurt/laravel-modules-core`.
+- PHP `^8.3` in composer, but this machine's default `php` is 8.3 while tests must run on 8.4. Use the Laragon 8.4 binary explicitly (see Toolchain).
+- `declare(strict_types=1);` at the top of every PHP file (matches existing core files).
+- Commits follow EpicAlgorithms git guidelines: **no AI attribution** in messages.
+- No DB, no HTTP, no Filament in M1 - pure in-memory registry.
+
+## Toolchain (this machine)
+
+`PHP84` = `C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe`
+
+- Tests: `"$PHP84" vendor/bin/pest`
+- Single file: `"$PHP84" vendor/bin/pest tests/Unit/Modules/ModuleManifestTest.php`
+- Stan: `"$PHP84" vendor/bin/phpstan analyse --memory-limit=2G`
+
+Work in the local clone `D:\Code\Projects\KurtModules-Core` (remote is `laravel-modules-core`).
+
+## File Structure
+
+- `src/Modules/ModuleManifest.php` - fluent value object; module's self-declaration.
+- `src/Contracts/ModuleRegistry.php` - registry contract (register/all/get/has).
+- `src/Modules/Registry.php` - in-memory `ModuleRegistry` implementation.
+- `src/Providers/PackageServiceProvider.php` - MODIFY: add `moduleManifest()` hook + register manifest in `packageBooted()`.
+- `src/Providers/CoreServiceProvider.php` - MODIFY: bind `ModuleRegistry` singleton.
+- `tests/Unit/Modules/ModuleManifestTest.php`, `tests/Unit/Modules/RegistryTest.php`, `tests/Feature/Modules/ModuleManifestRegistrationTest.php`.
+
+---
+
+## Task 1: ModuleManifest value object
+
+**Files:**
+- Create: `src/Modules/ModuleManifest.php`
+- Test: `tests/Unit/Modules/ModuleManifestTest.php`
+
+**Interfaces:**
+- Produces: `Kurt\Modules\Core\Modules\ModuleManifest` with static `make(string $slug): self`; fluent setters `name(string): self`, `version(string): self`, `description(string): self`, `enabledByDefault(bool = true): self`, `dependsOn(string ...$slugs): self`, `feature(string $key, bool $default = false): self`, `setting(string $key, mixed $default = null, string $type = 'string'): self`; getters `slug(): string`, `getName(): string`, `getVersion(): ?string`, `getDescription(): ?string`, `isEnabledByDefault(): bool`, `dependencies(): array`, `features(): array<string,bool>`, `hasFeature(string): bool`, `featureDefault(string): bool`, `settings(): array<string,array{default:mixed,type:string}>`, `hasSetting(string): bool`, `settingDefault(string): mixed`, `settingType(string): ?string`.
+
+- [ ] **Step 1: Write the failing test `tests/Unit/Modules/ModuleManifestTest.php`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Core\Modules\ModuleManifest;
+
+it('builds a manifest with defaults', function () {
+    $m = ModuleManifest::make('blog');
+
+    expect($m->slug())->toBe('blog')
+        ->and($m->getName())->toBe('blog')            // name defaults to slug
+        ->and($m->getVersion())->toBeNull()
+        ->and($m->getDescription())->toBeNull()
+        ->and($m->isEnabledByDefault())->toBeTrue()   // enabled unless opted out
+        ->and($m->dependencies())->toBe([])
+        ->and($m->features())->toBe([])
+        ->and($m->settings())->toBe([]);
+});
+
+it('builds a fully populated manifest fluently', function () {
+    $m = ModuleManifest::make('blog')
+        ->name('Blog')
+        ->version('1.0.0')
+        ->description('Blog module')
+        ->enabledByDefault(false)
+        ->dependsOn('interactions', 'media-library')
+        ->feature('comments', default: true)
+        ->feature('reactions')
+        ->setting('posts_per_page', default: 15, type: 'int');
+
+    expect($m->getName())->toBe('Blog')
+        ->and($m->getVersion())->toBe('1.0.0')
+        ->and($m->getDescription())->toBe('Blog module')
+        ->and($m->isEnabledByDefault())->toBeFalse()
+        ->and($m->dependencies())->toBe(['interactions', 'media-library'])
+        ->and($m->features())->toBe(['comments' => true, 'reactions' => false])
+        ->and($m->hasFeature('comments'))->toBeTrue()
+        ->and($m->featureDefault('comments'))->toBeTrue()
+        ->and($m->featureDefault('reactions'))->toBeFalse()
+        ->and($m->hasFeature('missing'))->toBeFalse()
+        ->and($m->featureDefault('missing'))->toBeFalse()
+        ->and($m->settings())->toBe(['posts_per_page' => ['default' => 15, 'type' => 'int']])
+        ->and($m->hasSetting('posts_per_page'))->toBeTrue()
+        ->and($m->settingDefault('posts_per_page'))->toBe(15)
+        ->and($m->settingType('posts_per_page'))->toBe('int')
+        ->and($m->hasSetting('missing'))->toBeFalse()
+        ->and($m->settingDefault('missing'))->toBeNull()
+        ->and($m->settingType('missing'))->toBeNull();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `"$PHP84" vendor/bin/pest tests/Unit/Modules/ModuleManifestTest.php`
+Expected: FAIL - `Class "Kurt\Modules\Core\Modules\ModuleManifest" not found`.
+
+- [ ] **Step 3: Write `src/Modules/ModuleManifest.php`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Modules;
+
+/**
+ * A module's self-declaration: identity, dependencies, and the feature/setting
+ * keys it exposes with their default values. Collected into the
+ * {@see \Kurt\Modules\Core\Contracts\ModuleRegistry} at boot. Pure value object -
+ * holds no runtime state and touches no DB.
+ */
+final class ModuleManifest
+{
+    private string $name;
+
+    private ?string $version = null;
+
+    private ?string $description = null;
+
+    private bool $enabledByDefault = true;
+
+    /** @var list<string> */
+    private array $dependencies = [];
+
+    /** @var array<string, bool> */
+    private array $features = [];
+
+    /** @var array<string, array{default: mixed, type: string}> */
+    private array $settings = [];
+
+    private function __construct(private readonly string $slug)
+    {
+        $this->name = $slug;
+    }
+
+    public static function make(string $slug): self
+    {
+        return new self($slug);
+    }
+
+    public function name(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function version(string $version): self
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    public function description(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function enabledByDefault(bool $enabled = true): self
+    {
+        $this->enabledByDefault = $enabled;
+
+        return $this;
+    }
+
+    public function dependsOn(string ...$slugs): self
+    {
+        foreach ($slugs as $slug) {
+            $this->dependencies[] = $slug;
+        }
+
+        return $this;
+    }
+
+    public function feature(string $key, bool $default = false): self
+    {
+        $this->features[$key] = $default;
+
+        return $this;
+    }
+
+    public function setting(string $key, mixed $default = null, string $type = 'string'): self
+    {
+        $this->settings[$key] = ['default' => $default, 'type' => $type];
+
+        return $this;
+    }
+
+    public function slug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getVersion(): ?string
+    {
+        return $this->version;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return $this->enabledByDefault;
+    }
+
+    /** @return list<string> */
+    public function dependencies(): array
+    {
+        return $this->dependencies;
+    }
+
+    /** @return array<string, bool> */
+    public function features(): array
+    {
+        return $this->features;
+    }
+
+    public function hasFeature(string $key): bool
+    {
+        return array_key_exists($key, $this->features);
+    }
+
+    public function featureDefault(string $key): bool
+    {
+        return $this->features[$key] ?? false;
+    }
+
+    /** @return array<string, array{default: mixed, type: string}> */
+    public function settings(): array
+    {
+        return $this->settings;
+    }
+
+    public function hasSetting(string $key): bool
+    {
+        return array_key_exists($key, $this->settings);
+    }
+
+    public function settingDefault(string $key): mixed
+    {
+        return $this->settings[$key]['default'] ?? null;
+    }
+
+    public function settingType(string $key): ?string
+    {
+        return $this->settings[$key]['type'] ?? null;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `"$PHP84" vendor/bin/pest tests/Unit/Modules/ModuleManifestTest.php`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Modules/ModuleManifest.php tests/Unit/Modules/ModuleManifestTest.php
+git commit -m "feat: add ModuleManifest value object"
+```
+
+---
+
+## Task 2: ModuleRegistry contract + in-memory Registry
+
+**Files:**
+- Create: `src/Contracts/ModuleRegistry.php`
+- Create: `src/Modules/Registry.php`
+- Test: `tests/Unit/Modules/RegistryTest.php`
+
+**Interfaces:**
+- Consumes: `ModuleManifest` from Task 1.
+- Produces: interface `Kurt\Modules\Core\Contracts\ModuleRegistry` with `register(ModuleManifest): void`, `all(): array<string, ModuleManifest>`, `get(string $slug): ?ModuleManifest`, `has(string $slug): bool`; class `Kurt\Modules\Core\Modules\Registry` implementing it (keyed by slug; `register` overwrites a same-slug entry).
+
+- [ ] **Step 1: Write the failing test `tests/Unit/Modules/RegistryTest.php`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Core\Contracts\ModuleRegistry;
+use Kurt\Modules\Core\Modules\ModuleManifest;
+use Kurt\Modules\Core\Modules\Registry;
+
+it('registers and retrieves manifests keyed by slug', function () {
+    $registry = new Registry();
+    expect($registry)->toBeInstanceOf(ModuleRegistry::class);
+
+    $blog = ModuleManifest::make('blog');
+    $chat = ModuleManifest::make('chat');
+    $registry->register($blog);
+    $registry->register($chat);
+
+    expect($registry->has('blog'))->toBeTrue()
+        ->and($registry->has('chat'))->toBeTrue()
+        ->and($registry->has('missing'))->toBeFalse()
+        ->and($registry->get('blog'))->toBe($blog)
+        ->and($registry->get('missing'))->toBeNull()
+        ->and(array_keys($registry->all()))->toBe(['blog', 'chat']);
+});
+
+it('overwrites a manifest registered under the same slug', function () {
+    $registry = new Registry();
+    $first = ModuleManifest::make('blog')->version('1.0.0');
+    $second = ModuleManifest::make('blog')->version('2.0.0');
+
+    $registry->register($first);
+    $registry->register($second);
+
+    expect($registry->all())->toHaveCount(1)
+        ->and($registry->get('blog'))->toBe($second);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `"$PHP84" vendor/bin/pest tests/Unit/Modules/RegistryTest.php`
+Expected: FAIL - `Interface "Kurt\Modules\Core\Contracts\ModuleRegistry" not found`.
+
+- [ ] **Step 3: Write `src/Contracts/ModuleRegistry.php`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Contracts;
+
+use Kurt\Modules\Core\Modules\ModuleManifest;
+
+interface ModuleRegistry
+{
+    public function register(ModuleManifest $manifest): void;
+
+    /** @return array<string, ModuleManifest> */
+    public function all(): array;
+
+    public function get(string $slug): ?ModuleManifest;
+
+    public function has(string $slug): bool;
+}
+```
+
+- [ ] **Step 4: Write `src/Modules/Registry.php`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Modules;
+
+use Kurt\Modules\Core\Contracts\ModuleRegistry;
+
+/**
+ * In-memory module registry. Populated once per request during package boot
+ * (see {@see \Kurt\Modules\Core\Providers\PackageServiceProvider}); a later
+ * same-slug registration overwrites the earlier one.
+ */
+final class Registry implements ModuleRegistry
+{
+    /** @var array<string, ModuleManifest> */
+    private array $modules = [];
+
+    public function register(ModuleManifest $manifest): void
+    {
+        $this->modules[$manifest->slug()] = $manifest;
+    }
+
+    /** @return array<string, ModuleManifest> */
+    public function all(): array
+    {
+        return $this->modules;
+    }
+
+    public function get(string $slug): ?ModuleManifest
+    {
+        return $this->modules[$slug] ?? null;
+    }
+
+    public function has(string $slug): bool
+    {
+        return isset($this->modules[$slug]);
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `"$PHP84" vendor/bin/pest tests/Unit/Modules/RegistryTest.php`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Contracts/ModuleRegistry.php src/Modules/Registry.php tests/Unit/Modules/RegistryTest.php
+git commit -m "feat: add ModuleRegistry contract and in-memory Registry"
+```
+
+---
+
+## Task 3: Wire manifest declaration into the provider lifecycle
+
+**Files:**
+- Modify: `src/Providers/CoreServiceProvider.php` (bind `ModuleRegistry` singleton)
+- Modify: `src/Providers/PackageServiceProvider.php` (add `moduleManifest()` hook + register in `packageBooted()`)
+- Test: `tests/Feature/Modules/ModuleManifestRegistrationTest.php`
+
+**Interfaces:**
+- Consumes: `ModuleRegistry`, `Registry`, `ModuleManifest` from Tasks 1-2.
+- Produces: `ModuleRegistry` resolvable from the container as a singleton; base `PackageServiceProvider::moduleManifest(): ?ModuleManifest` (default `null`) that subclasses override to self-register. Subclasses overriding `packageBooted()` must call `parent::packageBooted()` (already the documented convention).
+
+- [ ] **Step 1: Write the failing test `tests/Feature/Modules/ModuleManifestRegistrationTest.php`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Core\Contracts\ModuleRegistry;
+use Kurt\Modules\Core\Modules\ModuleManifest;
+use Kurt\Modules\Core\Providers\PackageServiceProvider;
+use Kurt\Modules\Core\Testing\PackageTestCase;
+use Spatie\LaravelPackageTools\Package;
+
+/** A throwaway module provider that declares a manifest. */
+final class DemoModuleServiceProvider extends PackageServiceProvider
+{
+    protected function module(): string
+    {
+        return 'demo';
+    }
+
+    public function configurePackage(Package $package): void
+    {
+        $package->name('demo');
+    }
+
+    protected function moduleManifest(): ?ModuleManifest
+    {
+        return ModuleManifest::make('demo')->name('Demo')->feature('thing', default: true);
+    }
+}
+
+final class ModuleManifestRegistrationTest extends PackageTestCase
+{
+    /** @param  \Illuminate\Foundation\Application  $app */
+    protected function modulePackageProviders($app): array
+    {
+        return [DemoModuleServiceProvider::class];
+    }
+
+    public function test_core_binds_the_registry_as_a_singleton(): void
+    {
+        $this->assertInstanceOf(ModuleRegistry::class, $this->app->make(ModuleRegistry::class));
+        $this->assertSame($this->app->make(ModuleRegistry::class), $this->app->make(ModuleRegistry::class));
+    }
+
+    public function test_a_module_provider_declares_its_manifest_into_the_registry(): void
+    {
+        $registry = $this->app->make(ModuleRegistry::class);
+
+        $this->assertTrue($registry->has('demo'));
+        $this->assertSame('Demo', $registry->get('demo')->getName());
+        $this->assertTrue($registry->get('demo')->featureDefault('thing'));
+    }
+
+    public function test_a_provider_without_a_manifest_registers_nothing(): void
+    {
+        // Core itself declares no manifest; only 'demo' should be present.
+        $this->assertSame(['demo'], array_keys($this->app->make(ModuleRegistry::class)->all()));
+    }
+}
+```
+
+Note: this test uses xUnit-style (`PackageTestCase` subclass) rather than Pest closures because it needs `modulePackageProviders()` to register the demo provider - matching how the core package's existing feature tests wire module providers.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `"$PHP84" vendor/bin/pest tests/Feature/Modules/ModuleManifestRegistrationTest.php`
+Expected: FAIL - `ModuleRegistry` is not bound (`BindingResolutionException`) / `moduleManifest()` undefined.
+
+- [ ] **Step 3: Bind the registry singleton in `CoreServiceProvider`**
+
+In `src/Providers/CoreServiceProvider.php`, add the imports and extend `packageRegistered()`:
+
+```php
+use Kurt\Modules\Core\Contracts\ModuleRegistry;
+use Kurt\Modules\Core\Modules\Registry;
+```
+
+```php
+    public function packageRegistered(): void
+    {
+        $this->app->singleton(UserResolver::class, fn ($app) => new ConfigUserResolver($app['config']));
+        $this->app->singleton(ModuleRegistry::class, fn () => new Registry());
+    }
+```
+
+- [ ] **Step 4: Add the `moduleManifest()` hook and registration to the base `PackageServiceProvider`**
+
+In `src/Providers/PackageServiceProvider.php`, add imports:
+
+```php
+use Kurt\Modules\Core\Contracts\ModuleRegistry;
+use Kurt\Modules\Core\Modules\ModuleManifest;
+```
+
+Replace the existing `packageBooted()` method with one that also registers the manifest, and add the two new methods:
+
+```php
+    public function packageBooted(): void
+    {
+        parent::packageBooted();
+
+        $this->registerModuleManifest();
+
+        $this->registerFilament();
+    }
+
+    /**
+     * Register this module's manifest into the registry, if it declares one.
+     * Runs in the boot phase, after CoreServiceProvider's register phase has
+     * bound the {@see ModuleRegistry} singleton.
+     */
+    private function registerModuleManifest(): void
+    {
+        $manifest = $this->moduleManifest();
+
+        if ($manifest instanceof ModuleManifest) {
+            $this->app->make(ModuleRegistry::class)->register($manifest);
+        }
+    }
+
+    /**
+     * A module overrides this to declare itself into the registry. Returning
+     * null (the default) means the package is not a managed module.
+     */
+    protected function moduleManifest(): ?ModuleManifest
+    {
+        return null;
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `"$PHP84" vendor/bin/pest tests/Feature/Modules/ModuleManifestRegistrationTest.php`
+Expected: PASS (3 passed).
+
+- [ ] **Step 6: Run the full suite + static analysis**
+
+Run: `"$PHP84" vendor/bin/pest`
+Expected: PASS (all green, including pre-existing core tests).
+
+Run: `"$PHP84" vendor/bin/phpstan analyse --memory-limit=2G`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Providers/CoreServiceProvider.php src/Providers/PackageServiceProvider.php tests/Feature/Modules/ModuleManifestRegistrationTest.php
+git commit -m "feat: collect module manifests into the registry at boot"
+```
+
+---
+
+## Done Criteria
+
+- `ModuleManifest::make('x')->feature(...)->setting(...)` builds a full self-declaration with the getters in Task 1.
+- `ModuleRegistry` is a container singleton; module providers self-register their manifest at boot via the `moduleManifest()` hook; a provider without one registers nothing.
+- Full Pest suite + PHPStan green under PHP 8.4.
+
+## Out of Scope (later milestones)
+
+- M2: DB tables, `ModuleManager` resolution (scope -> global -> manifest default), `ScopeResolver`, caching, `Modules` facade - in the `laravel-modules-manager` package.
+- M3: REST API + `EnsureModuleEnabled` middleware.
+- Rolling out `moduleManifest()` overrides to the 10 family modules (mechanical follow-up once the mechanism ships).

--- a/docs/superpowers/specs/2026-07-23-module-management-design.md
+++ b/docs/superpowers/specs/2026-07-23-module-management-design.md
@@ -1,0 +1,139 @@
+# Module Management Layer - Tasarım Dokümanı
+
+- **Tarih:** 2026-07-23
+- **Paketler:** `ozankurt/laravel-modules-core` (contract + registry) + yeni `ozankurt/laravel-modules-manager` (DB + API)
+- **Durum:** Tasarım onaylandı, implementasyon planı bekliyor
+- **Teslim modu:** headless + API (Filament/UI yok)
+
+## 1. Amaç
+
+KurtModules ailesi (core + 10 modül) için, tüketici uygulamanın modülleri **runtime'da yönetebildiği** bir katman: hangi modül açık, modül feature flag'leri, ve modül ayarları. Yönetim **global default + per-scope override** olarak, headless servis veya REST API üzerinden yapılır. Filament/UI kapsam dışı.
+
+Mevcut zemin (core): `HttpMode` (config-driven per-module yükleme modu), `InteractsWithModuleConfig`, `UserResolver`, `PackageServiceProvider`. Bu katman bunların **üstüne** oturur; DB-backed state/feature/ayar + registry ekler.
+
+## 2. İki katmanlı ayrım
+
+**Core (contract + registry, DB YOK - yalın kalır):**
+- `ModuleManifest` value object (fluent builder) + `ModuleRegistry` contract.
+- Her modülün ServiceProvider'ı `moduleManifest()` ile kendini declare eder.
+- Core boot'ta tüm kayıtlı provider'lardan manifest'leri toplayıp **in-memory registry** kurar. "Ne var ve defaultları ne" için tek doğruluk kaynağı. Tablo/model yok.
+
+**`laravel-modules-manager` (yeni paket, namespace `Kurt\Modules\Manager`):**
+- DB tabloları + modeller, `ModuleManager` servisi, `ScopeResolver` contract, REST API (HttpMode gate'li). Core'u require eder.
+- Bağımlılık yönü: manager → core. Modüller sadece core'un contract'ını bilir, manager'ı bilmez.
+
+## 3. Manifest (modül kendini nasıl tanıtır)
+
+Core `PackageServiceProvider` tabanına eklenen metod:
+
+```php
+protected function moduleManifest(): ModuleManifest
+{
+    return ModuleManifest::make('blog')
+        ->name('Blog')
+        ->version('1.0.0')
+        ->description('...')
+        ->dependsOn('interactions')
+        ->feature('comments', default: true)
+        ->feature('reactions', default: false)
+        ->setting('posts_per_page', default: 15, type: 'int');
+}
+```
+
+Fluent builder (keşfedilebilir, tip-güvenli, IDE dostu). Registry bunları toplar.
+
+**Disiplin:** manifest'te declare edilmemiş modül/feature/setting DB'de set edilemez → drift engellenir, registry otorite.
+
+## 4. Çözümleme ve ModuleManager
+
+`ModuleManager` (manager paketi) etkin değeri şu zincirle çözer:
+
+```
+scope satırı → global satır → manifest default → hard default
+```
+
+- `enabled(slug, scope=null): bool`
+- `feature(slug, key, scope=null): bool`
+- `setting(slug, key, scope=null): mixed`
+
+**Enabled default:** declare edilmiş (kurulu) bir modül varsayılan olarak **açıktır** (hard default = `true`); yani DB satırı yoksa modül enabled. Opt-in modüller manifest'te `->enabledByDefault(false)` ile bunu tersine çevirebilir. Feature/setting hard default'ları ise manifest'teki değerdir (feature yoksa `false`, setting yoksa `null`).
+
+Scope explicit verilmezse `ScopeResolver::current()` ile alınır (null → global). `ScopeResolver`, core'daki `UserResolver` gibi tüketicinin implemente ettiği bir contract - böylece herhangi bir tenancy paketine bağlanmadan generic kalır.
+
+Yazma: `setEnabled/setFeature/setSetting`, global veya belirli scope için DB'ye yazar.
+
+**Cache:** etkin değerler `(scope, slug)` başına cache'lenir, yazımda invalidate edilir - her request'te DB'ye gidilmez. Cache okuması fail-open.
+
+## 5. "Açık/kapalı" semantiği (boot-time gerçeği)
+
+Provider'lar **her zaman register olur** (binding/migration var olsun). Bir modülün route/API yüzeyi request anında `EnsureModuleEnabled($slug)` middleware'i ile korunur: scope için kapalıysa 404 (config'lenebilir davranış). Yani on/off **request anında DB-driven**, provider yükle/kaldır değil.
+
+Gerekçe: service provider'lar framework bootstrap'ta, DB sorgulanmadan önce boot olur. O yüzden "paketi yükle/yükleme" kararı DB'den yönetilemez; ama route/behavior request anında cache'li bir DB okumasıyla gate'lenebilir. Feature flag'ler alt-davranışları aynı şekilde gate'ler.
+
+## 6. Veri modeli
+
+Tek birleşik tablo (üç ayrı tablo yerine - tek resolution path + tek migration):
+
+```
+module_states
+  id
+  scope_type  (nullable)   -- null = global
+  scope_id    (nullable)
+  module      (slug)
+  kind        enum(state|feature|setting)
+  key         (nullable)   -- state: null; feature/setting: 'comments'/'posts_per_page'
+  value       (json)
+  timestamps
+  unique(scope_type, scope_id, module, kind, key)
+```
+
+- `kind=state, key=null` → enabled flag
+- `kind=feature, key='comments'` → feature override
+- `kind=setting, key='posts_per_page'` → ayar override
+- Global satırlar: scope_type/scope_id null
+
+Tradeoff: tek tablo = tek çözümleme yolu + tek migration, ama `value` polymorphic (json). Üç tablo daha tipli olurdu ama üç kat kod. Yalınlık için birleşik.
+
+## 7. API yüzeyi (HttpMode `api`)
+
+REST uçları (manager HttpMode + auth middleware gate'li, core `ApiController` envelope):
+
+```
+GET   /modules                        registry + current scope için etkin durum
+GET   /modules/{slug}                 tek modül (manifest + etkin değerler)
+PATCH /modules/{slug}                 enabled set (global veya scope - header/param)
+PATCH /modules/{slug}/features/{key}  feature set
+PATCH /modules/{slug}/settings/{key}  setting set
+```
+
+Scope istekte header/param ile belirtilir (yoksa global). Headless modda aynı işlemler `Modules` facade/servisiyle. `api` kapalıysa (headless) route kaydı olmaz.
+
+## 8. Hata yönetimi ve güvenlik
+
+- **Registry otorite:** manifest'te olmayan modül/feature/setting set edilemez → 422/404.
+- **Safe default:** DB satırı yok → manifest default → hard default. Cache fail-open.
+- **Scope:** yoksa global; bilinmeyen scope → global'e düşer.
+- **Setting tipi:** manifest'teki `type` ile validate edilir (int/bool/string/json).
+
+## 9. Test stratejisi
+
+- Çözümleme precedence matrisi: scope/global/manifest-default/hard-default her kombinasyon.
+- `EnsureModuleEnabled` gate (açık/kapalı, scope'lu/global).
+- HttpMode başına API (headless = route yok, api = envelope).
+- Manifest toplama (registry tüm provider'lardan doğru topluyor mu).
+- Cache invalidation (yazım sonrası etkin değer güncelleniyor mu).
+- Pest + core `PackageTestCase`.
+
+## 10. Milestone'lara bölme
+
+Sistem büyük; üç milestone, her biri tek başına çalışır+test edilir, ayrı spec→plan alır:
+
+- **M1 (core):** `ModuleManifest` + `ModuleRegistry` contract + `PackageServiceProvider.moduleManifest()` entegrasyonu; aile modülleri manifest declare eder. DB yok. → İlk somut plan bu.
+- **M2 (manager pkg):** DB + `ModuleManager` çözümleme (state/feature/setting) + `ScopeResolver` + cache. Headless servisler + `Modules` facade.
+- **M3 (manager pkg):** REST API + `EnsureModuleEnabled` middleware.
+
+## 11. Açık kararlar / v2
+
+- Modül **bağımlılık zorlaması** (Blog `dependsOn` interactions ama interactions kapalı) → M1'de manifest'te declare edilir, **zorlama/uyarı** v2.
+- Filament UI → kapsam dışı; ileride manager üstüne ayrı `ui` modu.
+- Scope başına toplu import/export ayar → v2.

--- a/src/Contracts/ModuleRegistry.php
+++ b/src/Contracts/ModuleRegistry.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Contracts;
+
+use Kurt\Modules\Core\Modules\ModuleManifest;
+
+interface ModuleRegistry
+{
+    public function register(ModuleManifest $manifest): void;
+
+    /** @return array<string, ModuleManifest> */
+    public function all(): array;
+
+    public function get(string $slug): ?ModuleManifest;
+
+    public function has(string $slug): bool;
+}

--- a/src/Modules/ModuleManifest.php
+++ b/src/Modules/ModuleManifest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Modules;
+
+/**
+ * A module's self-declaration: identity, dependencies, and the feature/setting
+ * keys it exposes with their default values. Collected into the
+ * {@see \Kurt\Modules\Core\Contracts\ModuleRegistry} at boot. Pure value object -
+ * holds no runtime state and touches no DB.
+ */
+final class ModuleManifest
+{
+    private string $name;
+
+    private ?string $version = null;
+
+    private ?string $description = null;
+
+    private bool $enabledByDefault = true;
+
+    /** @var list<string> */
+    private array $dependencies = [];
+
+    /** @var array<string, bool> */
+    private array $features = [];
+
+    /** @var array<string, array{default: mixed, type: string}> */
+    private array $settings = [];
+
+    private function __construct(private readonly string $slug)
+    {
+        $this->name = $slug;
+    }
+
+    public static function make(string $slug): self
+    {
+        return new self($slug);
+    }
+
+    public function name(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function version(string $version): self
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    public function description(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function enabledByDefault(bool $enabled = true): self
+    {
+        $this->enabledByDefault = $enabled;
+
+        return $this;
+    }
+
+    public function dependsOn(string ...$slugs): self
+    {
+        foreach ($slugs as $slug) {
+            $this->dependencies[] = $slug;
+        }
+
+        return $this;
+    }
+
+    public function feature(string $key, bool $default = false): self
+    {
+        $this->features[$key] = $default;
+
+        return $this;
+    }
+
+    public function setting(string $key, mixed $default = null, string $type = 'string'): self
+    {
+        $this->settings[$key] = ['default' => $default, 'type' => $type];
+
+        return $this;
+    }
+
+    public function slug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getVersion(): ?string
+    {
+        return $this->version;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function isEnabledByDefault(): bool
+    {
+        return $this->enabledByDefault;
+    }
+
+    /** @return list<string> */
+    public function dependencies(): array
+    {
+        return $this->dependencies;
+    }
+
+    /** @return array<string, bool> */
+    public function features(): array
+    {
+        return $this->features;
+    }
+
+    public function hasFeature(string $key): bool
+    {
+        return array_key_exists($key, $this->features);
+    }
+
+    public function featureDefault(string $key): bool
+    {
+        return $this->features[$key] ?? false;
+    }
+
+    /** @return array<string, array{default: mixed, type: string}> */
+    public function settings(): array
+    {
+        return $this->settings;
+    }
+
+    public function hasSetting(string $key): bool
+    {
+        return array_key_exists($key, $this->settings);
+    }
+
+    public function settingDefault(string $key): mixed
+    {
+        return $this->settings[$key]['default'] ?? null;
+    }
+
+    public function settingType(string $key): ?string
+    {
+        return $this->settings[$key]['type'] ?? null;
+    }
+}

--- a/src/Modules/Registry.php
+++ b/src/Modules/Registry.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Modules;
+
+use Kurt\Modules\Core\Contracts\ModuleRegistry;
+
+/**
+ * In-memory module registry. Populated once per request during package boot
+ * (see {@see \Kurt\Modules\Core\Providers\PackageServiceProvider}); a later
+ * same-slug registration overwrites the earlier one.
+ */
+final class Registry implements ModuleRegistry
+{
+    /** @var array<string, ModuleManifest> */
+    private array $modules = [];
+
+    public function register(ModuleManifest $manifest): void
+    {
+        $this->modules[$manifest->slug()] = $manifest;
+    }
+
+    /** @return array<string, ModuleManifest> */
+    public function all(): array
+    {
+        return $this->modules;
+    }
+
+    public function get(string $slug): ?ModuleManifest
+    {
+        return $this->modules[$slug] ?? null;
+    }
+
+    public function has(string $slug): bool
+    {
+        return isset($this->modules[$slug]);
+    }
+}

--- a/src/Providers/CoreServiceProvider.php
+++ b/src/Providers/CoreServiceProvider.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Kurt\Modules\Core\Providers;
 
+use Kurt\Modules\Core\Contracts\ModuleRegistry;
 use Kurt\Modules\Core\Contracts\UserResolver;
+use Kurt\Modules\Core\Modules\Registry;
 use Kurt\Modules\Core\Support\ConfigUserResolver;
 use Spatie\LaravelPackageTools\Package;
 
@@ -25,5 +27,6 @@ final class CoreServiceProvider extends PackageServiceProvider
     public function packageRegistered(): void
     {
         $this->app->singleton(UserResolver::class, fn ($app) => new ConfigUserResolver($app['config']));
+        $this->app->singleton(ModuleRegistry::class, fn () => new Registry());
     }
 }

--- a/src/Providers/PackageServiceProvider.php
+++ b/src/Providers/PackageServiceProvider.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Kurt\Modules\Core\Providers;
 
 use Illuminate\Support\Facades\Route;
+use Kurt\Modules\Core\Contracts\ModuleRegistry;
 use Kurt\Modules\Core\Http\ApiRouteGroup;
 use Kurt\Modules\Core\Http\HttpMode;
+use Kurt\Modules\Core\Modules\ModuleManifest;
 use Kurt\Modules\Core\Support\ApiRateLimiter;
 use Kurt\Modules\Core\Support\FilamentVersion;
 use Spatie\LaravelPackageTools\PackageServiceProvider as BasePackageServiceProvider;
@@ -31,7 +33,32 @@ abstract class PackageServiceProvider extends BasePackageServiceProvider
     {
         parent::packageBooted();
 
+        $this->registerModuleManifest();
+
         $this->registerFilament();
+    }
+
+    /**
+     * Register this module's manifest into the registry, if it declares one.
+     * Runs in the boot phase, after CoreServiceProvider's register phase has
+     * bound the {@see ModuleRegistry} singleton.
+     */
+    private function registerModuleManifest(): void
+    {
+        $manifest = $this->moduleManifest();
+
+        if ($manifest instanceof ModuleManifest) {
+            $this->app->make(ModuleRegistry::class)->register($manifest);
+        }
+    }
+
+    /**
+     * A module overrides this to declare itself into the registry. Returning
+     * null (the default) means the package is not a managed module.
+     */
+    protected function moduleManifest(): ?ModuleManifest
+    {
+        return null;
     }
 
     /**

--- a/tests/Feature/Modules/ModuleManifestRegistrationTest.php
+++ b/tests/Feature/Modules/ModuleManifestRegistrationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Core\Contracts\ModuleRegistry;
+use Kurt\Modules\Core\Modules\ModuleManifest;
+use Kurt\Modules\Core\Providers\PackageServiceProvider;
+use Kurt\Modules\Core\Testing\PackageTestCase;
+use Spatie\LaravelPackageTools\Package;
+
+/** A throwaway module provider that declares a manifest. */
+final class DemoModuleServiceProvider extends PackageServiceProvider
+{
+    protected function module(): string
+    {
+        return 'demo';
+    }
+
+    public function configurePackage(Package $package): void
+    {
+        $package->name('demo');
+    }
+
+    protected function moduleManifest(): ?ModuleManifest
+    {
+        return ModuleManifest::make('demo')->name('Demo')->feature('thing', default: true);
+    }
+}
+
+final class ModuleManifestRegistrationTest extends PackageTestCase
+{
+    /** @param  \Illuminate\Foundation\Application  $app */
+    protected function modulePackageProviders($app): array
+    {
+        return [DemoModuleServiceProvider::class];
+    }
+
+    public function test_core_binds_the_registry_as_a_singleton(): void
+    {
+        $this->assertInstanceOf(ModuleRegistry::class, $this->app->make(ModuleRegistry::class));
+        $this->assertSame($this->app->make(ModuleRegistry::class), $this->app->make(ModuleRegistry::class));
+    }
+
+    public function test_a_module_provider_declares_its_manifest_into_the_registry(): void
+    {
+        $registry = $this->app->make(ModuleRegistry::class);
+
+        $this->assertTrue($registry->has('demo'));
+        $this->assertSame('Demo', $registry->get('demo')->getName());
+        $this->assertTrue($registry->get('demo')->featureDefault('thing'));
+    }
+
+    public function test_a_provider_without_a_manifest_registers_nothing(): void
+    {
+        // Core itself declares no manifest; only 'demo' should be present.
+        $this->assertSame(['demo'], array_keys($this->app->make(ModuleRegistry::class)->all()));
+    }
+}

--- a/tests/Unit/Modules/ModuleManifestTest.php
+++ b/tests/Unit/Modules/ModuleManifestTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Core\Modules\ModuleManifest;
+
+it('builds a manifest with defaults', function () {
+    $m = ModuleManifest::make('blog');
+
+    expect($m->slug())->toBe('blog')
+        ->and($m->getName())->toBe('blog')            // name defaults to slug
+        ->and($m->getVersion())->toBeNull()
+        ->and($m->getDescription())->toBeNull()
+        ->and($m->isEnabledByDefault())->toBeTrue()   // enabled unless opted out
+        ->and($m->dependencies())->toBe([])
+        ->and($m->features())->toBe([])
+        ->and($m->settings())->toBe([]);
+});
+
+it('builds a fully populated manifest fluently', function () {
+    $m = ModuleManifest::make('blog')
+        ->name('Blog')
+        ->version('1.0.0')
+        ->description('Blog module')
+        ->enabledByDefault(false)
+        ->dependsOn('interactions', 'media-library')
+        ->feature('comments', default: true)
+        ->feature('reactions')
+        ->setting('posts_per_page', default: 15, type: 'int');
+
+    expect($m->getName())->toBe('Blog')
+        ->and($m->getVersion())->toBe('1.0.0')
+        ->and($m->getDescription())->toBe('Blog module')
+        ->and($m->isEnabledByDefault())->toBeFalse()
+        ->and($m->dependencies())->toBe(['interactions', 'media-library'])
+        ->and($m->features())->toBe(['comments' => true, 'reactions' => false])
+        ->and($m->hasFeature('comments'))->toBeTrue()
+        ->and($m->featureDefault('comments'))->toBeTrue()
+        ->and($m->featureDefault('reactions'))->toBeFalse()
+        ->and($m->hasFeature('missing'))->toBeFalse()
+        ->and($m->featureDefault('missing'))->toBeFalse()
+        ->and($m->settings())->toBe(['posts_per_page' => ['default' => 15, 'type' => 'int']])
+        ->and($m->hasSetting('posts_per_page'))->toBeTrue()
+        ->and($m->settingDefault('posts_per_page'))->toBe(15)
+        ->and($m->settingType('posts_per_page'))->toBe('int')
+        ->and($m->hasSetting('missing'))->toBeFalse()
+        ->and($m->settingDefault('missing'))->toBeNull()
+        ->and($m->settingType('missing'))->toBeNull();
+});

--- a/tests/Unit/Modules/RegistryTest.php
+++ b/tests/Unit/Modules/RegistryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Core\Contracts\ModuleRegistry;
+use Kurt\Modules\Core\Modules\ModuleManifest;
+use Kurt\Modules\Core\Modules\Registry;
+
+it('registers and retrieves manifests keyed by slug', function () {
+    $registry = new Registry();
+    expect($registry)->toBeInstanceOf(ModuleRegistry::class);
+
+    $blog = ModuleManifest::make('blog');
+    $chat = ModuleManifest::make('chat');
+    $registry->register($blog);
+    $registry->register($chat);
+
+    expect($registry->has('blog'))->toBeTrue()
+        ->and($registry->has('chat'))->toBeTrue()
+        ->and($registry->has('missing'))->toBeFalse()
+        ->and($registry->get('blog'))->toBe($blog)
+        ->and($registry->get('missing'))->toBeNull()
+        ->and(array_keys($registry->all()))->toBe(['blog', 'chat']);
+});
+
+it('overwrites a manifest registered under the same slug', function () {
+    $registry = new Registry();
+    $first = ModuleManifest::make('blog')->version('1.0.0');
+    $second = ModuleManifest::make('blog')->version('2.0.0');
+
+    $registry->register($first);
+    $registry->register($second);
+
+    expect($registry->all())->toHaveCount(1)
+        ->and($registry->get('blog'))->toBe($second);
+});


### PR DESCRIPTION
Adds the module self-declaration mechanism (M1 of the module-management layer).

- `ModuleManifest` fluent value object (slug, name, version, description, dependencies, feature defaults, setting defaults, enabled-by-default)
- `ModuleRegistry` contract + in-memory `Registry`, bound as a singleton by `CoreServiceProvider`
- `PackageServiceProvider::moduleManifest()` hook; manifests collected into the registry at boot

No DB, no API, no Filament (that is M2/M3). Full suite 86 passed, PHPStan clean under PHP 8.4.

Spec: docs/superpowers/specs/2026-07-23-module-management-design.md
Plan: docs/superpowers/plans/2026-07-23-module-management-m1-core-registry.md