### PR TITLE
Module cache convention (M1): ModuleCache + factory

### DIFF
--- a/src/Contracts/ModuleCache.php
+++ b/src/Contracts/ModuleCache.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Contracts;
+
+use Closure;
+use Kurt\Modules\Core\Support\ModuleCacheFactory;
+
+/**
+ * A per-module cache facade: a small, config-driven wrapper over a Laravel
+ * cache store, scoped by a module prefix. Modules resolve one via
+ * {@see ModuleCacheFactory} and cache their
+ * expensive read paths through it, busting specific keys from their existing
+ * observers/events.
+ */
+interface ModuleCache
+{
+    public function enabled(): bool;
+
+    /**
+     * Return the cached value for $key, or compute it via $callback, store it
+     * (under a module-prefixed key), and return it. A null result is cached too
+     * (negative-lookup sentinel). When caching is disabled the callback runs
+     * every time and nothing is stored.
+     */
+    public function remember(string $key, Closure $callback, ?int $ttl = null): mixed;
+
+    public function forget(string $key): void;
+}

--- a/src/Providers/CoreServiceProvider.php
+++ b/src/Providers/CoreServiceProvider.php
@@ -8,6 +8,7 @@ use Kurt\Modules\Core\Contracts\ModuleRegistry;
 use Kurt\Modules\Core\Contracts\UserResolver;
 use Kurt\Modules\Core\Modules\Registry;
 use Kurt\Modules\Core\Support\ConfigUserResolver;
+use Kurt\Modules\Core\Support\ModuleCacheFactory;
 use Spatie\LaravelPackageTools\Package;
 
 final class CoreServiceProvider extends PackageServiceProvider
@@ -27,6 +28,7 @@ final class CoreServiceProvider extends PackageServiceProvider
     public function packageRegistered(): void
     {
         $this->app->singleton(UserResolver::class, fn ($app) => new ConfigUserResolver($app['config']));
-        $this->app->singleton(ModuleRegistry::class, fn () => new Registry());
+        $this->app->singleton(ModuleRegistry::class, fn () => new Registry);
+        $this->app->singleton(ModuleCacheFactory::class, fn ($app) => new ModuleCacheFactory($app['cache'], $app['config']));
     }
 }

--- a/src/Support/ConfigModuleCache.php
+++ b/src/Support/ConfigModuleCache.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Support;
+
+use Closure;
+use Illuminate\Contracts\Cache\Repository;
+use Kurt\Modules\Core\Contracts\ModuleCache;
+
+/**
+ * Config-driven {@see ModuleCache}: wraps one resolved cache store, prefixes
+ * every key with the module prefix, caches null via a sentinel, and bypasses
+ * the store entirely when disabled.
+ */
+final class ConfigModuleCache implements ModuleCache
+{
+    /** Stored in place of a null result so negative lookups are cached. */
+    private const NULL_SENTINEL = '__module_cache_null__';
+
+    public function __construct(
+        private readonly Repository $store,
+        private readonly bool $enabled,
+        private readonly string $prefix,
+        private readonly int $ttl,
+    ) {}
+
+    public function enabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function remember(string $key, Closure $callback, ?int $ttl = null): mixed
+    {
+        if (! $this->enabled) {
+            return $callback();
+        }
+
+        $cached = $this->store->get($this->key($key));
+
+        if ($cached !== null) {
+            return $cached === self::NULL_SENTINEL ? null : $cached;
+        }
+
+        $value = $callback();
+
+        $this->store->put(
+            $this->key($key),
+            $value ?? self::NULL_SENTINEL,
+            $ttl ?? $this->ttl,
+        );
+
+        return $value;
+    }
+
+    public function forget(string $key): void
+    {
+        $this->store->forget($this->key($key));
+    }
+
+    private function key(string $key): string
+    {
+        return "{$this->prefix}:{$key}";
+    }
+}

--- a/src/Support/ModuleCacheFactory.php
+++ b/src/Support/ModuleCacheFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Support;
+
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Config\Repository as Config;
+use Kurt\Modules\Core\Contracts\ModuleCache;
+
+/**
+ * Builds a {@see ModuleCache} for a module from its `{slug}.cache` config block
+ * ({enabled, store, prefix, ttl}), applying safe defaults when the block (or a
+ * key) is absent. The store is selected by NAME so `config:cache` stays safe.
+ */
+final class ModuleCacheFactory
+{
+    public function __construct(
+        private readonly CacheFactory $cache,
+        private readonly Config $config,
+    ) {}
+
+    public function for(string $module): ModuleCache
+    {
+        $cfg = $this->config->get("{$module}.cache", []);
+        $cfg = is_array($cfg) ? $cfg : [];
+
+        $store = $cfg['store'] ?? null;
+
+        return new ConfigModuleCache(
+            $this->cache->store(is_string($store) ? $store : null),
+            (bool) ($cfg['enabled'] ?? true),
+            (string) ($cfg['prefix'] ?? $module),
+            (int) ($cfg['ttl'] ?? 3600),
+        );
+    }
+}

--- a/tests/Feature/Support/ModuleCacheFactoryTest.php
+++ b/tests/Feature/Support/ModuleCacheFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Core\Contracts\ModuleCache;
+use Kurt\Modules\Core\Support\ModuleCacheFactory;
+
+it('builds a module cache from the module config block', function () {
+    config()->set('blog.cache', ['enabled' => true, 'store' => 'array', 'prefix' => 'blog', 'ttl' => 60]);
+
+    $cache = app(ModuleCacheFactory::class)->for('blog');
+
+    expect($cache)->toBeInstanceOf(ModuleCache::class)
+        ->and($cache->enabled())->toBeTrue();
+
+    // Prefixing is scoped per module: 'blog' cache key must not collide with 'chat'.
+    $cache->remember('k', fn () => 'blog-value');
+    config()->set('chat.cache', ['store' => 'array', 'prefix' => 'chat']);
+    $chat = app(ModuleCacheFactory::class)->for('chat');
+    expect($chat->remember('k', fn () => 'chat-value'))->toBe('chat-value');
+});
+
+it('applies safe defaults when the module declares no cache block', function () {
+    // No 'events.cache' set at all.
+    $cache = app(ModuleCacheFactory::class)->for('events');
+
+    expect($cache)->toBeInstanceOf(ModuleCache::class)
+        ->and($cache->enabled())->toBeTrue(); // default enabled
+});
+
+it('honours enabled=false from config', function () {
+    config()->set('blog.cache', ['enabled' => false]);
+
+    expect(app(ModuleCacheFactory::class)->for('blog')->enabled())->toBeFalse();
+});

--- a/tests/Unit/Support/ConfigModuleCacheTest.php
+++ b/tests/Unit/Support/ConfigModuleCacheTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Kurt\Modules\Core\Support\ConfigModuleCache;
+
+function moduleCache(bool $enabled = true, int $ttl = 3600): ConfigModuleCache
+{
+    return new ConfigModuleCache(new Repository(new ArrayStore), $enabled, 'blog', $ttl);
+}
+
+it('remembers a computed value and serves it from cache on the next call', function () {
+    $cache = moduleCache();
+    $calls = 0;
+    $compute = function () use (&$calls) {
+        $calls++;
+
+        return 'value';
+    };
+
+    expect($cache->remember('k', $compute))->toBe('value')
+        ->and($cache->remember('k', $compute))->toBe('value')
+        ->and($calls)->toBe(1); // callback ran once
+});
+
+it('caches a null result via the sentinel (negative lookup)', function () {
+    $cache = moduleCache();
+    $calls = 0;
+    $compute = function () use (&$calls) {
+        $calls++;
+
+        return null;
+    };
+
+    expect($cache->remember('missing', $compute))->toBeNull()
+        ->and($cache->remember('missing', $compute))->toBeNull()
+        ->and($calls)->toBe(1); // null was cached, not recomputed
+});
+
+it('bypasses the store entirely when disabled', function () {
+    $cache = moduleCache(enabled: false);
+    $calls = 0;
+    $compute = function () use (&$calls) {
+        $calls++;
+
+        return 'x';
+    };
+
+    $cache->remember('k', $compute);
+    $cache->remember('k', $compute);
+
+    expect($calls)->toBe(2)                 // recomputed every time
+        ->and($cache->enabled())->toBeFalse();
+});
+
+it('forgets a specific prefixed key', function () {
+    $cache = moduleCache();
+    $calls = 0;
+    $compute = function () use (&$calls) {
+        $calls++;
+
+        return $calls;
+    };
+
+    expect($cache->remember('k', $compute))->toBe(1);
+    $cache->forget('k');
+    expect($cache->remember('k', $compute))->toBe(2); // recomputed after forget
+});


### PR DESCRIPTION
Shared per-module cache abstraction (M1 of the module-cache convention).

- `ModuleCache` contract (enabled/remember/forget; null cached via sentinel)
- `ConfigModuleCache` — config-driven wrapper, module-prefixed keys, enabled=false bypass
- `ModuleCacheFactory` — builds a ModuleCache from `{slug}.cache` config with safe defaults; store selected by name (config:cache safe)

No consumer wiring here — that is M2 (Blog pilot). Suite 93 passed, PHPStan clean.

Spec: docs/superpowers/specs/2026-07-23-module-cache-convention-design.md