### PR TITLE
Generational module cache (ACL M1)

### DIFF
--- a/src/Support/GenerationalModuleCache.php
+++ b/src/Support/GenerationalModuleCache.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Core\Support;
+
+use Closure;
+use Illuminate\Support\Str;
+use Kurt\Modules\Core\Contracts\ModuleCache;
+
+/**
+ * Generational (versioned) cache over a {@see ModuleCache}. Every entry is
+ * stored under a scope whose whole keyspace is invalidated in O(1) by
+ * {@see bump()}: bumping drops the scope's generation token, so the next read
+ * seeds a fresh one and every previously stored key is orphaned (never read
+ * again, expires by TTL). This avoids enumerating individual keys — the pattern
+ * behind safe ACL caching, where a permission or move change must invalidate an
+ * unbounded, hard-to-enumerate set of derived entries at once.
+ *
+ * Callers still put invalidation-relevant inputs INTO the key (e.g. a role
+ * fingerprint) so changes that have no bump signal self-invalidate.
+ */
+final class GenerationalModuleCache
+{
+    public function __construct(private readonly ModuleCache $cache) {}
+
+    public function remember(string $scope, string $key, Closure $callback, ?int $ttl = null): mixed
+    {
+        $generation = $this->generation($scope);
+
+        return $this->cache->remember("{$scope}:g{$generation}:{$key}", $callback, $ttl);
+    }
+
+    /** Current generation token for a scope, seeded fresh (and stored) if absent. */
+    public function generation(string $scope): string
+    {
+        return (string) $this->cache->remember("gen:{$scope}", fn () => Str::random(12));
+    }
+
+    /**
+     * Invalidate the entire scope. Dropping the generation token means the next
+     * {@see generation()} seeds a new one, so every key written under the old
+     * token is orphaned at once. Over-invalidation on token loss is safe (cold
+     * cache); it never serves a stale entry under the new token.
+     */
+    public function bump(string $scope): void
+    {
+        $this->cache->forget("gen:{$scope}");
+    }
+}

--- a/src/Support/ModuleCacheFactory.php
+++ b/src/Support/ModuleCacheFactory.php
@@ -34,4 +34,10 @@ final class ModuleCacheFactory
             (int) ($cfg['ttl'] ?? 3600),
         );
     }
+
+    /** A generational cache over the module's {@see ModuleCache} (see ACL caching). */
+    public function generationalFor(string $module): GenerationalModuleCache
+    {
+        return new GenerationalModuleCache($this->for($module));
+    }
 }

--- a/tests/Unit/Support/GenerationalModuleCacheTest.php
+++ b/tests/Unit/Support/GenerationalModuleCacheTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Kurt\Modules\Core\Support\ConfigModuleCache;
+use Kurt\Modules\Core\Support\GenerationalModuleCache;
+
+function genCache(bool $enabled = true): GenerationalModuleCache
+{
+    return new GenerationalModuleCache(new ConfigModuleCache(new Repository(new ArrayStore), $enabled, 'lib', 3600));
+}
+
+it('remembers a value under a scope and serves it from cache', function () {
+    $cache = genCache();
+    $calls = 0;
+    $compute = function () use (&$calls) {
+        $calls++;
+
+        return 'v';
+    };
+
+    expect($cache->remember('acl', 'k', $compute))->toBe('v')
+        ->and($cache->remember('acl', 'k', $compute))->toBe('v')
+        ->and($calls)->toBe(1);
+});
+
+it('bump() invalidates the entire scope in one call', function () {
+    $cache = genCache();
+    $calls = 0;
+    $compute = function () use (&$calls) {
+        $calls++;
+
+        return $calls;
+    };
+
+    expect($cache->remember('acl', 'a', $compute))->toBe(1)
+        ->and($cache->remember('acl', 'b', $compute))->toBe(2);
+
+    $cache->bump('acl'); // whole scope invalidated at once
+
+    // Both keys recompute under the new generation.
+    expect($cache->remember('acl', 'a', $compute))->toBe(3)
+        ->and($cache->remember('acl', 'b', $compute))->toBe(4);
+});
+
+it('keeps a stable generation token until bumped', function () {
+    $cache = genCache();
+
+    $first = $cache->generation('acl');
+    expect($cache->generation('acl'))->toBe($first); // stable
+
+    $cache->bump('acl');
+    expect($cache->generation('acl'))->not->toBe($first); // fresh token after bump
+});
+
+it('does not serve a stale entry under the new generation after bump', function () {
+    $cache = genCache();
+    $cache->remember('acl', 'k', fn () => 'granted');
+
+    $cache->bump('acl');
+
+    // After a bump the old value is orphaned: the fresh compute wins.
+    expect($cache->remember('acl', 'k', fn () => 'revoked'))->toBe('revoked');
+});


### PR DESCRIPTION
Adds GenerationalModuleCache: versioned cache over ModuleCache with O(1) scope invalidation via bump() (drops the generation token). Foundation for safe ACL caching (role fingerprint in key + generation bump on permission/move). Suite 97 passed, PHPStan clean.

Spec: docs/superpowers/specs/2026-07-29-acl-generational-cache-design.md