### PR TITLE
docs: document requirements, toolchain and CI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # laravel-modules-core
 
+[![tests](https://github.com/OzanKurt/laravel-modules-core/actions/workflows/tests.yml/badge.svg)](https://github.com/OzanKurt/laravel-modules-core/actions/workflows/tests.yml)
+
 Shared bootstrap kit for [KurtModules](https://github.com/ozankurt) Laravel packages.
 
 ## Requirements
 
-- PHP 8.4+
-- Laravel 13.x
+- PHP `^8.4`
+- Laravel `^13.0`
 - (Optional) Filament 3, 4, or 5
 
 ## Installation
@@ -206,6 +208,19 @@ Do **not** return a bare `JsonResource` from a route *and* also call `respond()`
 The outer group (prefix, base middleware, throttle, `"{slug}.api."` name prefix)
 is applied by `registerModuleApi()`; the route file only distinguishes read vs
 write.
+
+## Testing
+
+```bash
+composer install
+vendor/bin/pint --test
+vendor/bin/phpstan analyse --memory-limit=2G
+vendor/bin/pest
+```
+
+CI runs the same checks on every push and pull request
+(`.github/workflows/tests.yml`), against PHP 8.4 / Laravel 13. Static analysis
+is held at **PHPStan level 8**; the suite runs on **Pest 5**.
 
 ## License
 

--- a/src/Modules/ModuleManifest.php
+++ b/src/Modules/ModuleManifest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Kurt\Modules\Core\Modules;
 
+use Kurt\Modules\Core\Contracts\ModuleRegistry;
+
 /**
  * A module's self-declaration: identity, dependencies, and the feature/setting
  * keys it exposes with their default values. Collected into the
- * {@see \Kurt\Modules\Core\Contracts\ModuleRegistry} at boot. Pure value object -
+ * {@see ModuleRegistry} at boot. Pure value object -
  * holds no runtime state and touches no DB.
  */
 final class ModuleManifest

--- a/src/Modules/Registry.php
+++ b/src/Modules/Registry.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Kurt\Modules\Core\Modules;
 
 use Kurt\Modules\Core\Contracts\ModuleRegistry;
+use Kurt\Modules\Core\Providers\PackageServiceProvider;
 
 /**
  * In-memory module registry. Populated once per request during package boot
- * (see {@see \Kurt\Modules\Core\Providers\PackageServiceProvider}); a later
+ * (see {@see PackageServiceProvider}); a later
  * same-slug registration overwrites the earlier one.
  */
 final class Registry implements ModuleRegistry

--- a/tests/Feature/Modules/ModuleManifestRegistrationTest.php
+++ b/tests/Feature/Modules/ModuleManifestRegistrationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Foundation\Application;
 use Kurt\Modules\Core\Contracts\ModuleRegistry;
 use Kurt\Modules\Core\Modules\ModuleManifest;
 use Kurt\Modules\Core\Providers\PackageServiceProvider;
@@ -29,7 +30,7 @@ final class DemoModuleServiceProvider extends PackageServiceProvider
 
 final class ModuleManifestRegistrationTest extends PackageTestCase
 {
-    /** @param  \Illuminate\Foundation\Application  $app */
+    /** @param  Application  $app */
     protected function modulePackageProviders($app): array
     {
         return [DemoModuleServiceProvider::class];

--- a/tests/Unit/Modules/RegistryTest.php
+++ b/tests/Unit/Modules/RegistryTest.php
@@ -7,7 +7,7 @@ use Kurt\Modules\Core\Modules\ModuleManifest;
 use Kurt\Modules\Core\Modules\Registry;
 
 it('registers and retrieves manifests keyed by slug', function () {
-    $registry = new Registry();
+    $registry = new Registry;
     expect($registry)->toBeInstanceOf(ModuleRegistry::class);
 
     $blog = ModuleManifest::make('blog');
@@ -24,7 +24,7 @@ it('registers and retrieves manifests keyed by slug', function () {
 });
 
 it('overwrites a manifest registered under the same slug', function () {
-    $registry = new Registry();
+    $registry = new Registry;
     $first = ModuleManifest::make('blog')->version('1.0.0');
     $second = ModuleManifest::make('blog')->version('2.0.0');
 


### PR DESCRIPTION
Adds, derived from each package's own `composer.json` and workflow rather than assumed:

- a CI status badge
- a **Requirements** section (PHP `^8.4`, Laravel `^13.0`)
- a **Testing** section listing the checks CI actually enforces (Pint, PHPStan level 8, Pest 5)

Also repoints links at the post-rename `laravel-modules-core` repo. That includes the composer `repositories` VCS snippet, which pointed at the old `KurtModules-Core` path and therefore 404'd for anyone following the install instructions.

Docs only, no code change, so no version bump is needed.